### PR TITLE
Placeholder for needed fix

### DIFF
--- a/developers/weaviate/current/getting-started/installation.md
+++ b/developers/weaviate/current/getting-started/installation.md
@@ -27,6 +27,8 @@ There are multiple ways to set up a Weaviate instance. For a testing setup, we r
 You can use the configuration tool below to customize your Weaviate setup for
 your desired runtime (e.g. Docker-Compose, Kubernetes, etc.):
 
+***
+
 {% include docs-config-gen.html %}
 
 # Docker Compose


### PR DESCRIPTION
I was unable to find the body of text represented by the link to the docker-compose.yml configuration--> {% include docs-config-gen.html %} . A word in the instructions needs to be corrected which I included in parentheses.

...You can also select an older version for compatbility (compatibility) sake...