### PR TITLE
fix: link not redirecting

### DIFF
--- a/developers/weaviate/current/architecture/prefiltering.md
+++ b/developers/weaviate/current/architecture/prefiltering.md
@@ -44,7 +44,7 @@ combined inverted index and HNSW index.*
 # Efficient Pre-Filtered Searches in Weaviate
 
 In the section about Storage, [we have described in detail which parts make up a
-shard in Weaviate](../storage.html). Most notably, each shard contains an
+shard in Weaviate](./storage.html). Most notably, each shard contains an
 inverted index right next to the HNSW index. This allows for efficient
 pre-filtering. The process is as follows:
 


### PR DESCRIPTION
Fixes #79 

In this page https://weaviate.io/developers/weaviate/current/architecture/prefiltering.html#efficient-pre-filtered-searches-in-weaviate

the link to In the section about Storage, [we have described in detail which parts make up a shard in Weaviate](https://weaviate.io/developers/weaviate/current/storage.html). is now fixed.