### PR TITLE
Added jekyll-seo for better optimisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,5 @@ gem "jekyll-toc", "~> 0.17.1"
 gem "webrick", "~> 1.7"
 
 gem 'jekyll-redirect-from'
+
+gem 'jekyll-seo-tag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-toc (0.17.1)
       jekyll (>= 3.9)
       nokogiri (~> 1.11)
@@ -80,6 +82,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.2)
   jekyll-redirect-from
+  jekyll-seo-tag
   jekyll-toc (~> 0.17.1)
   webrick (~> 1.7)
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,23 @@
+name: Weaviate vector search engine
+
+# title of the website
+title: Weaviate Documentation
+
+# short description of the website
+description: Weaviate is an open source vector search engine that stores both objects and vectors, allowing for combining vector search with structured filtering with the fault-tolerance and scalability of a cloud-native database, all accessible through GraphQL, REST, and various language clients.
+
+mini_description: Weaviate is a cloud-native, modular, real-time vector search engine
+
+# website keywords for seo
+keywords: weaviate, vector, search, engine, cloud-native, modular
+
+twitter:
+  username: weaviate_io
+  card: summary
+
+website_repo: https://github.com/semi-technologies/weaviate-io
+url: https://weaviate.io/
+
 slack_signup_url: "https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw"
 weaviate_cli_version: 2.1.2
 python_client_version: 3.3.0
@@ -23,6 +43,7 @@ exclude:
 plugins:
     - jekyll-redirect-from
     - jekyll-toc
+    - jekyll-seo-tag
 whitelist:
     - jekyll-redirect-from
 toc:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,8 +24,8 @@
 
     <!-- Title -->
     {% if page.layout == "layout-documentation" %}
-        <title>{{ page.title }} · Weaviate Documentation</title>
-        <meta property="og:title" content="{{ page.title }} · Weaviate Documentation" />
+        <title>{{ page.title }} · {{ site.title }}</title>
+        <meta property="og:title" content="{{ page.title }} · {{ site.title }}" />
     {% else %}
         <title>{{ page.title }}</title>
         <meta property="og:title" content="{{ page.title }}" />
@@ -44,9 +44,17 @@
     {% endif %}
 
     <!-- OG final -->
-    <meta property="og:site_name" content="Weaviate vector search engine" />
+    <meta property="og:site_name" content="{{ site.name }}" />
     <meta property="og:type" content="website" />
+    <meta property="og:description" content="{{ site.description }}"/>
+    <meta property="og:url" content="{{ site.url }}"/>
+    <meta name="keywords" content="{{ site.keywords }}">
+    <meta property="twitter:title" content="{{ site.title }}"/>
+    <meta name="twitter:site" content="@{{ site.twitter.username }}"/>
+    <meta property="twitter:description" content="{{ site.mini_description }}"/>
+    <meta name="twitter:card" content="site.twitter.card">
 
     <!-- plausible -->
     {% include plausible.html %}
+    {% seo %}
 </head>


### PR DESCRIPTION
A Jekyll plugin to add metadata tags for search engines and social networks to better index and display your site's content. This plugin helps to optimise the site for better SEO. Read the docs [here](https://jekyll.github.io/jekyll-seo-tag/).

The changes I made adds the following meta tags to the site:

* Page title, with site title or description appended
* Page description
* Keywords
* Canonical URL
* [Twitter Summary Card](https://dev.twitter.com/cards/overview) metadata