### PR TITLE
feat: made installation easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 vendor/
 _site/
 .jekyll-metadata
+.ruby-version

--- a/readme.md
+++ b/readme.md
@@ -26,19 +26,6 @@ This repo contains the [Weaviate](https://weaviate.io) website, it's built using
 
   # install ruby 2.7.5
   rbenv install 2.7.5
-
-  # initialize rbenv
-  export PATH="$HOME/.rbenv/bin:$PATH"
-
-  # set the ruby version locally to 2.7.5
-  rbenv local 2.7.5
-  ```
-  - For installing RubyGems, read [docs](https://jekyllrb.com/docs/installation/ubuntu/)
-  ```bash
-  echo '# Install Ruby Gems to ~/gems' >> ~/.bashrc
-  echo 'export GEM_HOME="$HOME/gems"' >> ~/.bashrc
-  echo 'export PATH="$HOME/gems/bin:$PATH"' >> ~/.bashrc
-  source ~/.bashrc
   ```
 
 - Installing Dependencies Windows
@@ -52,12 +39,6 @@ This repo contains the [Weaviate](https://weaviate.io) website, it's built using
 
   # install ruby 2.7.5
   rbenv install 2.7.5
-
-  # initialize rbenv
-  eval "$(rbenv init -)"
-
-  # set the ruby version locally to 2.7.5
-  rbenv local 2.7.5
   ```
 
 - Check if dependencies are installed correctly
@@ -66,15 +47,6 @@ This repo contains the [Weaviate](https://weaviate.io) website, it's built using
   gem -v
   ```
 
-- Finally, install Jekyll and Bundler:
-  ```bash
-  gem install jekyll bundler
-  ```
-
-- Check if dependencies are installed correctly
-  ```bash
-  jekyll -v
-  ```
 ### Setting up the repository
   
 - To get the site up and running locally, follow the below steps:
@@ -98,12 +70,11 @@ This repo contains the [Weaviate](https://weaviate.io) website, it's built using
   ```
 - Perform the following commands to install dependencies and structure the website properly:
   ```
-  bundle config set --local path 'vendor/cache'
-  bundle install
+  ./setup.sh
   ```
 - Build the site and make it available on your local server
   ```
-  bundle exec jekyll serve
+  ./run.sh
   ```
 - Browse [http://localhost:4000](http://localhost:4000) to view the website.
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# set directories
+CURRENT_DIR=$(pwd)
+GEM_PATH=$CURRENT_DIR/.bundle
+BUNDLER_PATH=$GEM_PATH/bin
+
+# initialize rbenv
+export PATH="$HOME/.rbenv/bin:$PATH"
+eval "$(rbenv init -)"
+
+# set the ruby version locally to 2.7.5
+rbenv local 2.7.5
+
+echo -e "\n💡 \033[1;31mplease access via localhost and not 127.0.0.1! \033[0m"
+
+echo -e "\n🎉 \033[1;34mstarting jekyll \033[0m\n"
+
+$BUNDLER_PATH/bundle exec jekyll s --watch --livereload --host=localhost --baseurl=""

--- a/setup.sh
+++ b/setup.sh
@@ -25,6 +25,9 @@ echo -e "\n💡 \033[1;34minstalling bundler packages locally \033[0m\n"
 # set bundler path
 $BUNDLER_PATH/bundle config set --local path $GEM_PATH
 
+# set ffi options
+$BUNDLER_PATH/bundle config build.ffi --enable-libffi-alloc
+
 # install bundler dependencies
 $BUNDLER_PATH/bundle install --standalone
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# set directories
+CURRENT_DIR=$(pwd)
+GEM_PATH=$CURRENT_DIR/.bundle
+BUNDLER_PATH=$GEM_PATH/bin
+
+# initialize rbenv
+export PATH="$HOME/.rbenv/bin:$PATH"
+eval "$(rbenv init -)"
+
+# set the ruby version locally to 2.7.5
+rbenv local 2.7.5
+
+echo -e "\n💡 \033[1;34minstalling bundler locally \033[0m\n"
+
+# uninstall all other bundler versions
+gem uninstall bundler --all > /dev/null 2>&1
+
+# install bundler
+gem install bundler:2.3.8 --install-dir=$GEM_PATH --quiet --no-user-install
+
+echo -e "\n💡 \033[1;34minstalling bundler packages locally \033[0m\n"
+
+# set bundler path
+$BUNDLER_PATH/bundle config set --local path $GEM_PATH
+
+# install bundler dependencies
+$BUNDLER_PATH/bundle install --standalone
+
+echo -e "\n👌 \033[1;35minstallation finished \033[0m\n"


### PR DESCRIPTION
So, I asked 3 batch-mates (complete beginners) to just try their hand installing and setting up Weaviate's website. Told them to follow the steps mentioned in Readme. They followed the steps, but some were getting stuck while setting the bundle path or repeatedly typing `bundle exec jekyll serve` to run the site.

I came up with two install scripts to solve that issue, and make the installation even more easier.

So, `setup.sh` now, 
* Initialises directories
* Installs bundler and it's dependencies 
* Sets a local version of Ruby.

`run.sh` now,
* Initialises Ruby environment
* Serves the Jekyll site to localhost

Users can even see the progress of their setup because of `echo` commands.

for `setup.sh`
![Screenshot from 2022-04-24 23-30-17](https://user-images.githubusercontent.com/81866614/165017370-a0fafa8e-986e-4ae1-a908-c4be507de11b.png)

for `run.sh`
![Screenshot from 2022-04-24 23-34-07](https://user-images.githubusercontent.com/81866614/165017418-760ec46f-a93d-4fcb-b73d-dbab7cb42529.png)

