### PR TITLE
fix: version number in quickstart

### DIFF
--- a/developers/weaviate/current/getting-started/quick-start.md
+++ b/developers/weaviate/current/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 toc: true
@@ -22,7 +22,6 @@ There are many different ways to run Weaviate, from local development setups to 
 The Docker Compose files below will setup Weaviate and load the dataset.
 
 Download the Docker Compose file:
-
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-simple.yml
 ```
@@ -30,8 +29,7 @@ $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies
 This demo can also be GPU accelerated with the appropriate architecture and drivers.
 To enable GPU support on docker ([Docker GPU Support](https://docs.docker.com/config/containers/resource_constraints/#gpu))
 
-Start GPU enabled demo with this docker-compose file:
-
+Start GPU enabled demo with this docker-compose file: 
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-withgpu.yaml
 ```
@@ -69,15 +67,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "{{ site.weaviate_version}}"
 }
 ```
 
@@ -93,244 +90,277 @@ The output will looks like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5224,8 +5254,8 @@ You can also examine which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5244,11 +5274,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5261,6 +5291,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can add classic filters to narrow down your search.
 
 ```graphql
@@ -5268,7 +5299,11 @@ When querying for articles, you can add classic filters to narrow down your sear
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5278,27 +5313,27 @@ When querying for articles, you can add classic filters to narrow down your sear
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5326,15 +5361,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5343,13 +5383,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5360,8 +5407,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5371,23 +5418,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next...
-
 In this tutorial you learned how to quickly set up a Weaviate with a demo dataset, and use semantic search and classification. Next, check out the following:
-
 - [Spin up a Weaviate instance](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/current/getting-started/quick-start.md
+++ b/developers/weaviate/current/getting-started/quick-start.md
@@ -67,6 +67,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -74,7 +75,7 @@ The output will look like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/current/getting-started/quick-start.md
+++ b/developers/weaviate/current/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 toc: true
@@ -22,6 +22,7 @@ There are many different ways to run Weaviate, from local development setups to 
 The Docker Compose files below will setup Weaviate and load the dataset.
 
 Download the Docker Compose file:
+
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-simple.yml
 ```
@@ -29,7 +30,8 @@ $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies
 This demo can also be GPU accelerated with the appropriate architecture and drivers.
 To enable GPU support on docker ([Docker GPU Support](https://docs.docker.com/config/containers/resource_constraints/#gpu))
 
-Start GPU enabled demo with this docker-compose file: 
+Start GPU enabled demo with this docker-compose file:
+
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-withgpu.yaml
 ```
@@ -67,14 +69,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "{{ site.weaviate_version}}"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -90,277 +93,244 @@ The output will looks like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5254,8 +5224,8 @@ You can also examine which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5274,11 +5244,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5291,7 +5261,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can add classic filters to narrow down your search.
 
 ```graphql
@@ -5299,11 +5268,7 @@ When querying for articles, you can add classic filters to narrow down your sear
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5313,27 +5278,27 @@ When querying for articles, you can add classic filters to narrow down your sear
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5361,20 +5326,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5383,20 +5343,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5407,8 +5360,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5418,26 +5371,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next...
+
 In this tutorial you learned how to quickly set up a Weaviate with a demo dataset, and use semantic search and classification. Next, check out the following:
+
 - [Spin up a Weaviate instance](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.0.4/getting-started/quick-start.md
+++ b/developers/weaviate/v1.0.4/getting-started/quick-start.md
@@ -54,6 +54,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -64,7 +65,7 @@ The output will look something like this:
       "version": "en0.16.0-v0.4.21"
      }
   },
-  "version": "{{ site.weaviate_version }}"
+  "version": "{{ current_page_version }}"
 }
 
 ```

--- a/developers/weaviate/v1.0.4/getting-started/quick-start.md
+++ b/developers/weaviate/v1.0.4/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -54,7 +54,6 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -63,10 +62,11 @@ The output will look something like this:
     "text2vec-contextionary": {
       "wordCount": 818072,
       "version": "en0.16.0-v0.4.21"
-    }
+     }
   },
-  "version": "{{ current_page_version }}"
+  "version": "{{ site.weaviate_version }}"
 }
+
 ```
 
 This validates that your Weaviate is running correctly.
@@ -87,17 +87,23 @@ The output will look something like this:
       "description": "A publication with an online source",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "Name of the publication",
           "name": "name"
         },
         {
-          "dataType": ["geoCoordinates"],
+          "dataType": [
+            "geoCoordinates"
+          ],
           "description": "Geo location of the HQ",
           "name": "headquartersGeoLocation"
         },
         {
-          "dataType": ["Article"],
+          "dataType": [
+            "Article"
+          ],
           "description": "The articles this publication has",
           "name": "hasArticles"
         }
@@ -110,7 +116,9 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "Name of the author",
           "moduleConfig": {
             "text2vec-contextionary": {
@@ -120,12 +128,16 @@ The output will look something like this:
           "name": "name"
         },
         {
-          "dataType": ["Article"],
+          "dataType": [
+            "Article"
+          ],
           "description": "Articles this author wrote",
           "name": "wroteArticles"
         },
         {
-          "dataType": ["Publication"],
+          "dataType": [
+            "Publication"
+          ],
           "description": "The publication this author writes for",
           "name": "writesFor"
         }
@@ -138,7 +150,9 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "title of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -149,7 +163,9 @@ The output will look something like this:
           "name": "title"
         },
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "url of the article",
           "indexInverted": false,
           "moduleConfig": {
@@ -160,7 +176,9 @@ The output will look something like this:
           "name": "url"
         },
         {
-          "dataType": ["text"],
+          "dataType": [
+            "text"
+          ],
           "description": "summary of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -171,32 +189,45 @@ The output will look something like this:
           "name": "summary"
         },
         {
-          "dataType": ["date"],
+          "dataType": [
+            "date"
+          ],
           "description": "date of publication of the article",
           "name": "publicationDate"
         },
         {
-          "dataType": ["int"],
+          "dataType": [
+            "int"
+          ],
           "description": "Words in this article",
           "name": "wordCount"
         },
         {
-          "dataType": ["boolean"],
+          "dataType": [
+            "boolean"
+          ],
           "description": "whether the article is currently accessible through the url",
           "name": "isAccessible"
         },
         {
-          "dataType": ["Author", "Publication"],
+          "dataType": [
+            "Author",
+            "Publication"
+          ],
           "description": "authors this article has",
           "name": "hasAuthors"
         },
         {
-          "dataType": ["Publication"],
+          "dataType": [
+            "Publication"
+          ],
           "description": "publication this article is in",
           "name": "inPublication"
         },
         {
-          "dataType": ["Category"],
+          "dataType": [
+            "Category"
+          ],
           "description": "category this article is of",
           "name": "ofCategory"
         }
@@ -209,7 +240,9 @@ The output will look something like this:
       "description": "Category an article is a type off",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "category name",
           "indexInverted": true,
           "moduleConfig": {
@@ -5090,7 +5123,7 @@ When querying Weaviate, you will always be using the GraphQL API. Weaviate has a
 
 ### Accessing the Console
 
-Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/).
+Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/). 
 
 ### Your First Query
 
@@ -5117,8 +5150,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5137,11 +5170,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5154,6 +5187,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5161,7 +5195,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5171,27 +5209,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5219,15 +5257,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5236,13 +5279,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5253,8 +5303,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5264,14 +5314,19 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.05 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.05
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.05%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
+
 
 # Automatic classification
 
@@ -5292,8 +5347,8 @@ If you run the following query, you might notice that there are no categories cl
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article+%7B%0D%0A++++++title%0D%0A++++++ofCategory+%7B%0D%0A++++++++...+on+Category+%7B%0D%0A++++++++++name%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Here we can use Weaviate's auto-classification function to let Weaviate decide which categories to attach to news publications.
 
@@ -5331,6 +5386,7 @@ When Weaviate is done with the classification, you can rerun the previous query 
 }
 ```
 
+
 By using the RESTful API, you can even get statistics related to the classification. You can find the `{CLASSIFICATION ID}` in the returned body of the query that started the classification.
 
 ```bash
@@ -5338,13 +5394,11 @@ $ curl -k http://localhost:8080/v1/classifications/{CLASSIFICATION ID} | jq .
 ```
 
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.0.4/getting-started/quick-start.md
+++ b/developers/weaviate/v1.0.4/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -54,6 +54,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -62,11 +63,10 @@ The output will look something like this:
     "text2vec-contextionary": {
       "wordCount": 818072,
       "version": "en0.16.0-v0.4.21"
-     }
+    }
   },
-  "version": "{{ site.weaviate_version }}"
+  "version": "{{ current_page_version }}"
 }
-
 ```
 
 This validates that your Weaviate is running correctly.
@@ -87,23 +87,17 @@ The output will look something like this:
       "description": "A publication with an online source",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "Name of the publication",
           "name": "name"
         },
         {
-          "dataType": [
-            "geoCoordinates"
-          ],
+          "dataType": ["geoCoordinates"],
           "description": "Geo location of the HQ",
           "name": "headquartersGeoLocation"
         },
         {
-          "dataType": [
-            "Article"
-          ],
+          "dataType": ["Article"],
           "description": "The articles this publication has",
           "name": "hasArticles"
         }
@@ -116,9 +110,7 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "Name of the author",
           "moduleConfig": {
             "text2vec-contextionary": {
@@ -128,16 +120,12 @@ The output will look something like this:
           "name": "name"
         },
         {
-          "dataType": [
-            "Article"
-          ],
+          "dataType": ["Article"],
           "description": "Articles this author wrote",
           "name": "wroteArticles"
         },
         {
-          "dataType": [
-            "Publication"
-          ],
+          "dataType": ["Publication"],
           "description": "The publication this author writes for",
           "name": "writesFor"
         }
@@ -150,9 +138,7 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "title of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -163,9 +149,7 @@ The output will look something like this:
           "name": "title"
         },
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "url of the article",
           "indexInverted": false,
           "moduleConfig": {
@@ -176,9 +160,7 @@ The output will look something like this:
           "name": "url"
         },
         {
-          "dataType": [
-            "text"
-          ],
+          "dataType": ["text"],
           "description": "summary of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -189,45 +171,32 @@ The output will look something like this:
           "name": "summary"
         },
         {
-          "dataType": [
-            "date"
-          ],
+          "dataType": ["date"],
           "description": "date of publication of the article",
           "name": "publicationDate"
         },
         {
-          "dataType": [
-            "int"
-          ],
+          "dataType": ["int"],
           "description": "Words in this article",
           "name": "wordCount"
         },
         {
-          "dataType": [
-            "boolean"
-          ],
+          "dataType": ["boolean"],
           "description": "whether the article is currently accessible through the url",
           "name": "isAccessible"
         },
         {
-          "dataType": [
-            "Author",
-            "Publication"
-          ],
+          "dataType": ["Author", "Publication"],
           "description": "authors this article has",
           "name": "hasAuthors"
         },
         {
-          "dataType": [
-            "Publication"
-          ],
+          "dataType": ["Publication"],
           "description": "publication this article is in",
           "name": "inPublication"
         },
         {
-          "dataType": [
-            "Category"
-          ],
+          "dataType": ["Category"],
           "description": "category this article is of",
           "name": "ofCategory"
         }
@@ -240,9 +209,7 @@ The output will look something like this:
       "description": "Category an article is a type off",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "category name",
           "indexInverted": true,
           "moduleConfig": {
@@ -5123,7 +5090,7 @@ When querying Weaviate, you will always be using the GraphQL API. Weaviate has a
 
 ### Accessing the Console
 
-Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/). 
+Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/).
 
 ### Your First Query
 
@@ -5150,8 +5117,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5170,11 +5137,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5187,7 +5154,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5195,11 +5161,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5209,27 +5171,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5257,20 +5219,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5279,20 +5236,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5303,8 +5253,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5314,19 +5264,14 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.05
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.05 }) {
       name
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.05%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.05%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
 # Automatic classification
 
@@ -5347,8 +5292,8 @@ If you run the following query, you might notice that there are no categories cl
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article+%7B%0D%0A++++++title%0D%0A++++++ofCategory+%7B%0D%0A++++++++...+on+Category+%7B%0D%0A++++++++++name%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article+%7B%0D%0A++++++title%0D%0A++++++ofCategory+%7B%0D%0A++++++++...+on+Category+%7B%0D%0A++++++++++name%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Here we can use Weaviate's auto-classification function to let Weaviate decide which categories to attach to news publications.
 
@@ -5386,7 +5331,6 @@ When Weaviate is done with the classification, you can rerun the previous query 
 }
 ```
 
-
 By using the RESTful API, you can even get statistics related to the classification. You can find the `{CLASSIFICATION ID}` in the returned body of the query that started the classification.
 
 ```bash
@@ -5394,11 +5338,13 @@ $ curl -k http://localhost:8080/v1/classifications/{CLASSIFICATION ID} | jq .
 ```
 
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.1.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.1.0/getting-started/quick-start.md
@@ -54,6 +54,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -64,7 +65,7 @@ The output will look something like this:
       "version": "en0.16.0-v0.4.21"
      }
   },
-  "version": "{{ site.weaviate_version }}"
+  "version": "{{ current_page_version }}"
 }
 
 ```

--- a/developers/weaviate/v1.1.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.1.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -54,7 +54,6 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -63,10 +62,11 @@ The output will look something like this:
     "text2vec-contextionary": {
       "wordCount": 818072,
       "version": "en0.16.0-v0.4.21"
-    }
+     }
   },
-  "version": "{{ current_page_version }}"
+  "version": "{{ site.weaviate_version }}"
 }
+
 ```
 
 This validates that your Weaviate is running correctly.
@@ -87,17 +87,23 @@ The output will look something like this:
       "description": "A publication with an online source",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "Name of the publication",
           "name": "name"
         },
         {
-          "dataType": ["geoCoordinates"],
+          "dataType": [
+            "geoCoordinates"
+          ],
           "description": "Geo location of the HQ",
           "name": "headquartersGeoLocation"
         },
         {
-          "dataType": ["Article"],
+          "dataType": [
+            "Article"
+          ],
           "description": "The articles this publication has",
           "name": "hasArticles"
         }
@@ -110,7 +116,9 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "Name of the author",
           "moduleConfig": {
             "text2vec-contextionary": {
@@ -120,12 +128,16 @@ The output will look something like this:
           "name": "name"
         },
         {
-          "dataType": ["Article"],
+          "dataType": [
+            "Article"
+          ],
           "description": "Articles this author wrote",
           "name": "wroteArticles"
         },
         {
-          "dataType": ["Publication"],
+          "dataType": [
+            "Publication"
+          ],
           "description": "The publication this author writes for",
           "name": "writesFor"
         }
@@ -138,7 +150,9 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "title of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -149,7 +163,9 @@ The output will look something like this:
           "name": "title"
         },
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "url of the article",
           "indexInverted": false,
           "moduleConfig": {
@@ -160,7 +176,9 @@ The output will look something like this:
           "name": "url"
         },
         {
-          "dataType": ["text"],
+          "dataType": [
+            "text"
+          ],
           "description": "summary of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -171,32 +189,45 @@ The output will look something like this:
           "name": "summary"
         },
         {
-          "dataType": ["date"],
+          "dataType": [
+            "date"
+          ],
           "description": "date of publication of the article",
           "name": "publicationDate"
         },
         {
-          "dataType": ["int"],
+          "dataType": [
+            "int"
+          ],
           "description": "Words in this article",
           "name": "wordCount"
         },
         {
-          "dataType": ["boolean"],
+          "dataType": [
+            "boolean"
+          ],
           "description": "whether the article is currently accessible through the url",
           "name": "isAccessible"
         },
         {
-          "dataType": ["Author", "Publication"],
+          "dataType": [
+            "Author",
+            "Publication"
+          ],
           "description": "authors this article has",
           "name": "hasAuthors"
         },
         {
-          "dataType": ["Publication"],
+          "dataType": [
+            "Publication"
+          ],
           "description": "publication this article is in",
           "name": "inPublication"
         },
         {
-          "dataType": ["Category"],
+          "dataType": [
+            "Category"
+          ],
           "description": "category this article is of",
           "name": "ofCategory"
         }
@@ -209,7 +240,9 @@ The output will look something like this:
       "description": "Category an article is a type off",
       "properties": [
         {
-          "dataType": ["string"],
+          "dataType": [
+            "string"
+          ],
           "description": "category name",
           "indexInverted": true,
           "moduleConfig": {
@@ -5090,7 +5123,7 @@ When querying Weaviate, you will always be using the GraphQL API. Weaviate has a
 
 ### Accessing the Console
 
-Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/).
+Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/). 
 
 ### Your First Query
 
@@ -5117,8 +5150,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5137,11 +5170,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5154,6 +5187,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5161,7 +5195,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5171,27 +5209,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5219,15 +5257,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5236,13 +5279,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5253,8 +5303,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5264,14 +5314,19 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.05 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.05
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.05%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
+
 
 # Automatic classification
 
@@ -5292,8 +5347,8 @@ If you run the following query, you might notice that there are no categories cl
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article+%7B%0D%0A++++++title%0D%0A++++++ofCategory+%7B%0D%0A++++++++...+on+Category+%7B%0D%0A++++++++++name%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Here we can use Weaviate's auto-classification function to let Weaviate decide which categories to attach to news publications.
 
@@ -5331,6 +5386,7 @@ When Weaviate is done with the classification, you can rerun the previous query 
 }
 ```
 
+
 By using the RESTful API, you can even get statistics related to the classification. You can find the `{CLASSIFICATION ID}` in the returned body of the query that started the classification.
 
 ```bash
@@ -5338,13 +5394,11 @@ $ curl -k http://localhost:8080/v1/classifications/{CLASSIFICATION ID} | jq .
 ```
 
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.1.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.1.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -54,6 +54,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -62,11 +63,10 @@ The output will look something like this:
     "text2vec-contextionary": {
       "wordCount": 818072,
       "version": "en0.16.0-v0.4.21"
-     }
+    }
   },
-  "version": "{{ site.weaviate_version }}"
+  "version": "{{ current_page_version }}"
 }
-
 ```
 
 This validates that your Weaviate is running correctly.
@@ -87,23 +87,17 @@ The output will look something like this:
       "description": "A publication with an online source",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "Name of the publication",
           "name": "name"
         },
         {
-          "dataType": [
-            "geoCoordinates"
-          ],
+          "dataType": ["geoCoordinates"],
           "description": "Geo location of the HQ",
           "name": "headquartersGeoLocation"
         },
         {
-          "dataType": [
-            "Article"
-          ],
+          "dataType": ["Article"],
           "description": "The articles this publication has",
           "name": "hasArticles"
         }
@@ -116,9 +110,7 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "Name of the author",
           "moduleConfig": {
             "text2vec-contextionary": {
@@ -128,16 +120,12 @@ The output will look something like this:
           "name": "name"
         },
         {
-          "dataType": [
-            "Article"
-          ],
+          "dataType": ["Article"],
           "description": "Articles this author wrote",
           "name": "wroteArticles"
         },
         {
-          "dataType": [
-            "Publication"
-          ],
+          "dataType": ["Publication"],
           "description": "The publication this author writes for",
           "name": "writesFor"
         }
@@ -150,9 +138,7 @@ The output will look something like this:
       "description": "Normalised types",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "title of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -163,9 +149,7 @@ The output will look something like this:
           "name": "title"
         },
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "url of the article",
           "indexInverted": false,
           "moduleConfig": {
@@ -176,9 +160,7 @@ The output will look something like this:
           "name": "url"
         },
         {
-          "dataType": [
-            "text"
-          ],
+          "dataType": ["text"],
           "description": "summary of the article",
           "indexInverted": true,
           "moduleConfig": {
@@ -189,45 +171,32 @@ The output will look something like this:
           "name": "summary"
         },
         {
-          "dataType": [
-            "date"
-          ],
+          "dataType": ["date"],
           "description": "date of publication of the article",
           "name": "publicationDate"
         },
         {
-          "dataType": [
-            "int"
-          ],
+          "dataType": ["int"],
           "description": "Words in this article",
           "name": "wordCount"
         },
         {
-          "dataType": [
-            "boolean"
-          ],
+          "dataType": ["boolean"],
           "description": "whether the article is currently accessible through the url",
           "name": "isAccessible"
         },
         {
-          "dataType": [
-            "Author",
-            "Publication"
-          ],
+          "dataType": ["Author", "Publication"],
           "description": "authors this article has",
           "name": "hasAuthors"
         },
         {
-          "dataType": [
-            "Publication"
-          ],
+          "dataType": ["Publication"],
           "description": "publication this article is in",
           "name": "inPublication"
         },
         {
-          "dataType": [
-            "Category"
-          ],
+          "dataType": ["Category"],
           "description": "category this article is of",
           "name": "ofCategory"
         }
@@ -240,9 +209,7 @@ The output will look something like this:
       "description": "Category an article is a type off",
       "properties": [
         {
-          "dataType": [
-            "string"
-          ],
+          "dataType": ["string"],
           "description": "category name",
           "indexInverted": true,
           "moduleConfig": {
@@ -5123,7 +5090,7 @@ When querying Weaviate, you will always be using the GraphQL API. Weaviate has a
 
 ### Accessing the Console
 
-Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/). 
+Go to [console.semi.technology](https://console.semi.technology). Log in and connect to your Weaviate instance, and then go to 'Query' in the left menu. Or go directly to [the GraphQL query page](https://console.semi.technology/modules/graphql-query/).
 
 ### Your First Query
 
@@ -5150,8 +5117,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5170,11 +5137,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5187,7 +5154,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5195,11 +5161,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5209,27 +5171,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5257,20 +5219,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5279,20 +5236,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5303,8 +5253,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5314,19 +5264,14 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.05
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.05 }) {
       name
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.05%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.05%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
 # Automatic classification
 
@@ -5347,8 +5292,8 @@ If you run the following query, you might notice that there are no categories cl
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article+%7B%0D%0A++++++title%0D%0A++++++ofCategory+%7B%0D%0A++++++++...+on+Category+%7B%0D%0A++++++++++name%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article+%7B%0D%0A++++++title%0D%0A++++++ofCategory+%7B%0D%0A++++++++...+on+Category+%7B%0D%0A++++++++++name%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Here we can use Weaviate's auto-classification function to let Weaviate decide which categories to attach to news publications.
 
@@ -5386,7 +5331,6 @@ When Weaviate is done with the classification, you can rerun the previous query 
 }
 ```
 
-
 By using the RESTful API, you can even get statistics related to the classification. You can find the `{CLASSIFICATION ID}` in the returned body of the query that started the classification.
 
 ```bash
@@ -5394,11 +5338,13 @@ $ curl -k http://localhost:8080/v1/classifications/{CLASSIFICATION ID} | jq .
 ```
 
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.10.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.10.1/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og: /img/og/og-documentation/getting-started-quick-start.jpg
@@ -64,14 +64,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "{{ site.weaviate_version}}"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -87,277 +88,244 @@ The output will looks like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5251,8 +5219,8 @@ You can also examine which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5271,11 +5239,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5288,7 +5256,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can add classic filters to narrow down your search.
 
 ```graphql
@@ -5296,11 +5263,7 @@ When querying for articles, you can add classic filters to narrow down your sear
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5310,27 +5273,27 @@ When querying for articles, you can add classic filters to narrow down your sear
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5358,20 +5321,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5380,20 +5338,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5404,8 +5355,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5415,26 +5366,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next...
+
 In this tutorial you learned how to quickly set up a Weaviate with a demo dataset, and use semantic search and classification. Next, check out the following:
+
 - [Spin up a Weaviate instance](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.10.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.10.1/getting-started/quick-start.md
@@ -64,6 +64,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -71,7 +72,7 @@ The output will look like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.10.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.10.1/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og: /img/og/og-documentation/getting-started-quick-start.jpg
@@ -64,15 +64,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "{{ site.weaviate_version}}"
 }
 ```
 
@@ -88,244 +87,277 @@ The output will looks like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5219,8 +5251,8 @@ You can also examine which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5239,11 +5271,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5256,6 +5288,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can add classic filters to narrow down your search.
 
 ```graphql
@@ -5263,7 +5296,11 @@ When querying for articles, you can add classic filters to narrow down your sear
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5273,27 +5310,27 @@ When querying for articles, you can add classic filters to narrow down your sear
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5321,15 +5358,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5338,13 +5380,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5355,8 +5404,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5366,23 +5415,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next...
-
 In this tutorial you learned how to quickly set up a Weaviate with a demo dataset, and use semantic search and classification. Next, check out the following:
-
 - [Spin up a Weaviate instance](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.11.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.11.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 toc: true
@@ -22,7 +22,6 @@ There are many different ways to run Weaviate, from local development setups to 
 The Docker Compose files below will setup Weaviate and load the dataset.
 
 Download the Docker Compose file:
-
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-simple.yml
 ```
@@ -30,8 +29,7 @@ $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies
 This demo can also be GPU accelerated with the appropiate architecture and drivers.
 To enable GPU support on docker ([Docker GPU Support](https://docs.docker.com/config/containers/resource_constraints/#gpu))
 
-Start GPU enbaled demo with this docker-compose file:
-
+Start GPU enbaled demo with this docker-compose file: 
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-withgpu.yaml
 ```
@@ -69,15 +67,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "{{ site.weaviate_version}}"
 }
 ```
 
@@ -93,244 +90,277 @@ The output will looks like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5224,8 +5254,8 @@ You can also examine which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5244,11 +5274,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5261,6 +5291,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can add classic filters to narrow down your search.
 
 ```graphql
@@ -5268,7 +5299,11 @@ When querying for articles, you can add classic filters to narrow down your sear
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5278,27 +5313,27 @@ When querying for articles, you can add classic filters to narrow down your sear
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5326,15 +5361,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5343,13 +5383,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5360,8 +5407,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5371,23 +5418,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next...
-
 In this tutorial you learned how to quickly set up a Weaviate with a demo dataset, and use semantic search and classification. Next, check out the following:
-
 - [Spin up a Weaviate instance](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.11.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.11.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 toc: true
@@ -22,6 +22,7 @@ There are many different ways to run Weaviate, from local development setups to 
 The Docker Compose files below will setup Weaviate and load the dataset.
 
 Download the Docker Compose file:
+
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-simple.yml
 ```
@@ -29,7 +30,8 @@ $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies
 This demo can also be GPU accelerated with the appropiate architecture and drivers.
 To enable GPU support on docker ([Docker GPU Support](https://docs.docker.com/config/containers/resource_constraints/#gpu))
 
-Start GPU enbaled demo with this docker-compose file: 
+Start GPU enbaled demo with this docker-compose file:
+
 ```bash
 $ curl -o docker-compose.yml https://raw.githubusercontent.com/semi-technologies/weaviate-examples/main/weaviate-transformers-newspublications/docker-compose-withgpu.yaml
 ```
@@ -67,14 +69,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "{{ site.weaviate_version}}"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -90,277 +93,244 @@ The output will looks like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5254,8 +5224,8 @@ You can also examine which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5274,11 +5244,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5291,7 +5261,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can add classic filters to narrow down your search.
 
 ```graphql
@@ -5299,11 +5268,7 @@ When querying for articles, you can add classic filters to narrow down your sear
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5313,27 +5278,27 @@ When querying for articles, you can add classic filters to narrow down your sear
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5361,20 +5326,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5383,20 +5343,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5407,8 +5360,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5418,26 +5371,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next...
+
 In this tutorial you learned how to quickly set up a Weaviate with a demo dataset, and use semantic search and classification. Next, check out the following:
+
 - [Spin up a Weaviate instance](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all the possible interactions with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.11.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.11.0/getting-started/quick-start.md
@@ -67,6 +67,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -74,7 +75,7 @@ The output will look like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.2.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.2.1/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -58,14 +58,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "1.2.1"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -81,277 +82,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5245,8 +5213,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5265,11 +5233,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5282,7 +5250,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5290,11 +5257,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5304,27 +5267,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5352,20 +5315,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5374,20 +5332,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5398,8 +5349,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5409,26 +5360,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.2.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.2.1/getting-started/quick-start.md
@@ -58,6 +58,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -65,7 +66,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "1.2.1"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.2.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.2.1/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -58,15 +58,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "1.2.1"
 }
 ```
 
@@ -82,244 +81,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5213,8 +5245,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5233,11 +5265,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5250,6 +5282,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5257,7 +5290,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5267,27 +5304,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5315,15 +5352,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5332,13 +5374,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5349,8 +5398,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5360,23 +5409,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.3.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.3.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -58,14 +58,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "1.2.1"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -81,277 +82,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5245,8 +5213,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5265,11 +5233,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5282,7 +5250,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5290,11 +5257,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5304,27 +5267,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5352,20 +5315,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5374,20 +5332,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5398,8 +5349,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5409,26 +5360,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.3.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.3.0/getting-started/quick-start.md
@@ -58,6 +58,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -65,7 +66,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "1.2.1"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.3.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.3.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -58,15 +58,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "1.2.1"
 }
 ```
 
@@ -82,244 +81,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5213,8 +5245,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5233,11 +5265,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5250,6 +5282,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5257,7 +5290,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5267,27 +5304,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5315,15 +5352,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5332,13 +5374,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5349,8 +5398,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5360,23 +5409,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.4.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.4.1/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,15 +64,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "1.2.1"
 }
 ```
 
@@ -88,244 +87,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5219,8 +5251,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5239,11 +5271,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5256,6 +5288,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5263,7 +5296,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5273,27 +5310,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5321,15 +5358,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5338,13 +5380,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5355,8 +5404,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5366,23 +5415,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.4.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.4.1/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,14 +64,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "1.2.1"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -87,277 +88,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5251,8 +5219,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5271,11 +5239,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5288,7 +5256,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5296,11 +5263,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5310,27 +5273,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5358,20 +5321,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5380,20 +5338,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5404,8 +5355,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5415,26 +5366,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.4.1/getting-started/quick-start.md
+++ b/developers/weaviate/v1.4.1/getting-started/quick-start.md
@@ -64,6 +64,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -71,7 +72,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "1.2.1"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.5.2/getting-started/quick-start.md
+++ b/developers/weaviate/v1.5.2/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,15 +64,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "1.2.1"
 }
 ```
 
@@ -88,244 +87,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5219,8 +5251,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5239,11 +5271,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5256,6 +5288,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5263,7 +5296,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5273,27 +5310,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5321,15 +5358,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5338,13 +5380,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5355,8 +5404,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5366,23 +5415,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.5.2/getting-started/quick-start.md
+++ b/developers/weaviate/v1.5.2/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,14 +64,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "1.2.1"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -87,277 +88,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5251,8 +5219,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5271,11 +5239,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5288,7 +5256,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5296,11 +5263,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5310,27 +5273,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5358,20 +5321,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5380,20 +5338,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5404,8 +5355,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5415,26 +5366,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.5.2/getting-started/quick-start.md
+++ b/developers/weaviate/v1.5.2/getting-started/quick-start.md
@@ -64,6 +64,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -71,7 +72,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "1.2.1"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.6.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.6.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,14 +64,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "{{ site.weaviate_version}}"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -87,277 +88,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5251,8 +5219,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5271,11 +5239,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5288,7 +5256,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5296,11 +5263,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5310,27 +5273,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5358,20 +5321,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5380,20 +5338,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5404,8 +5355,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5415,26 +5366,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.6.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.6.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,15 +64,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "{{ site.weaviate_version}}"
 }
 ```
 
@@ -88,244 +87,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5219,8 +5251,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5239,11 +5271,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5256,6 +5288,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5263,7 +5296,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5273,27 +5310,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5321,15 +5358,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5338,13 +5380,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5355,8 +5404,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5366,23 +5415,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.6.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.6.0/getting-started/quick-start.md
@@ -64,6 +64,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -71,7 +72,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.7.2/getting-started/quick-start.md
+++ b/developers/weaviate/v1.7.2/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,14 +64,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "{{ site.weaviate_version}}"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -87,277 +88,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5251,8 +5219,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5271,11 +5239,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5288,7 +5256,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5296,11 +5263,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5310,27 +5273,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5358,20 +5321,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5380,20 +5338,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5404,8 +5355,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5415,26 +5366,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.7.2/getting-started/quick-start.md
+++ b/developers/weaviate/v1.7.2/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,15 +64,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "{{ site.weaviate_version}}"
 }
 ```
 
@@ -88,244 +87,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5219,8 +5251,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5239,11 +5271,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5256,6 +5288,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5263,7 +5296,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5273,27 +5310,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5321,15 +5358,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5338,13 +5380,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5355,8 +5404,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5366,23 +5415,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.7.2/getting-started/quick-start.md
+++ b/developers/weaviate/v1.7.2/getting-started/quick-start.md
@@ -64,6 +64,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -71,7 +72,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.8.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.8.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,14 +64,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "{{ site.weaviate_version}}"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -87,277 +88,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5251,8 +5219,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5271,11 +5239,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5288,7 +5256,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5296,11 +5263,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5310,27 +5273,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5358,20 +5321,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5380,20 +5338,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5404,8 +5355,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5415,26 +5366,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.8.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.8.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,15 +64,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "{{ site.weaviate_version}}"
 }
 ```
 
@@ -88,244 +87,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5219,8 +5251,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5239,11 +5271,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5256,6 +5288,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5263,7 +5296,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5273,27 +5310,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5321,15 +5358,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5338,13 +5380,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5355,8 +5404,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5366,23 +5415,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.8.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.8.0/getting-started/quick-start.md
@@ -64,6 +64,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -71,7 +72,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 

--- a/developers/weaviate/v1.9.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.9.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ['quick start']
+tags: ["quick start"]
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,14 +64,15 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
-    "hostname": "http://[::]:8080",
-    "modules": {
-        "text2vec-transformers": {}
-    },
-    "version": "{{ site.weaviate_version}}"
+  "hostname": "http://[::]:8080",
+  "modules": {
+    "text2vec-transformers": {}
+  },
+  "version": "{{ current_page_version }}"
 }
 ```
 
@@ -87,277 +88,244 @@ The output will look something like this:
 
 ```json
 {
-    "classes": [
-        {
-            "class": "Publication",
-            "description": "A publication with an online source",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the publication",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "geoCoordinates"
-                    ],
-                    "description": "Geo location of the HQ",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "headquartersGeoLocation"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "The articles this publication has",
-                    "name": "hasArticles"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Author",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": true
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "Name of the author",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                },
-                {
-                    "dataType": [
-                        "Article"
-                    ],
-                    "description": "Articles this author wrote",
-                    "name": "wroteArticles"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "The publication this author writes for",
-                    "name": "writesFor"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Article",
-            "description": "Normalised types",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "title of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "title"
-                },
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "url of the article",
-                    "indexInverted": false,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "url"
-                },
-                {
-                    "dataType": [
-                        "text"
-                    ],
-                    "description": "summary of the article",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "summary"
-                },
-                {
-                    "dataType": [
-                        "date"
-                    ],
-                    "description": "date of publication of the article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "publicationDate"
-                },
-                {
-                    "dataType": [
-                        "int"
-                    ],
-                    "description": "Words in this article",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "wordCount"
-                },
-                {
-                    "dataType": [
-                        "boolean"
-                    ],
-                    "description": "whether the article is currently accessible through the url",
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "isAccessible"
-                },
-                {
-                    "dataType": [
-                        "Author",
-                        "Publication"
-                    ],
-                    "description": "authors this article has",
-                    "name": "hasAuthors"
-                },
-                {
-                    "dataType": [
-                        "Publication"
-                    ],
-                    "description": "publication this article is in",
-                    "name": "inPublication"
-                },
-                {
-                    "dataType": [
-                        "Category"
-                    ],
-                    "description": "category this article is of",
-                    "name": "ofCategory"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
-        },
-        {
-            "class": "Category",
-            "description": "Category an article is a type off",
-            "invertedIndexConfig": {
-                "cleanupIntervalSeconds": 60
-            },
-            "moduleConfig": {
-                "text2vec-transformers": {
-                    "poolingStrategy": "masked_mean",
-                    "vectorizeClassName": false
-                }
-            },
-            "properties": [
-                {
-                    "dataType": [
-                        "string"
-                    ],
-                    "description": "category name",
-                    "indexInverted": true,
-                    "moduleConfig": {
-                        "text2vec-transformers": {
-                            "skip": false,
-                            "vectorizePropertyName": false
-                        }
-                    },
-                    "name": "name"
-                }
-            ],
-            "vectorIndexConfig": {
-                "cleanupIntervalSeconds": 300,
-                "maxConnections": 64,
-                "efConstruction": 128,
-                "vectorCacheMaxObjects": 500000
-            },
-            "vectorIndexType": "hnsw",
-            "vectorizer": "text2vec-transformers"
+  "classes": [
+    {
+      "class": "Publication",
+      "description": "A publication with an online source",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
         }
-    ]
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the publication",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["geoCoordinates"],
+          "description": "Geo location of the HQ",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "headquartersGeoLocation"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "The articles this publication has",
+          "name": "hasArticles"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Author",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": true
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "Name of the author",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        },
+        {
+          "dataType": ["Article"],
+          "description": "Articles this author wrote",
+          "name": "wroteArticles"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "The publication this author writes for",
+          "name": "writesFor"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Article",
+      "description": "Normalised types",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "title of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "title"
+        },
+        {
+          "dataType": ["string"],
+          "description": "url of the article",
+          "indexInverted": false,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "url"
+        },
+        {
+          "dataType": ["text"],
+          "description": "summary of the article",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "summary"
+        },
+        {
+          "dataType": ["date"],
+          "description": "date of publication of the article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "publicationDate"
+        },
+        {
+          "dataType": ["int"],
+          "description": "Words in this article",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "wordCount"
+        },
+        {
+          "dataType": ["boolean"],
+          "description": "whether the article is currently accessible through the url",
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "isAccessible"
+        },
+        {
+          "dataType": ["Author", "Publication"],
+          "description": "authors this article has",
+          "name": "hasAuthors"
+        },
+        {
+          "dataType": ["Publication"],
+          "description": "publication this article is in",
+          "name": "inPublication"
+        },
+        {
+          "dataType": ["Category"],
+          "description": "category this article is of",
+          "name": "ofCategory"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    },
+    {
+      "class": "Category",
+      "description": "Category an article is a type off",
+      "invertedIndexConfig": {
+        "cleanupIntervalSeconds": 60
+      },
+      "moduleConfig": {
+        "text2vec-transformers": {
+          "poolingStrategy": "masked_mean",
+          "vectorizeClassName": false
+        }
+      },
+      "properties": [
+        {
+          "dataType": ["string"],
+          "description": "category name",
+          "indexInverted": true,
+          "moduleConfig": {
+            "text2vec-transformers": {
+              "skip": false,
+              "vectorizePropertyName": false
+            }
+          },
+          "name": "name"
+        }
+      ],
+      "vectorIndexConfig": {
+        "cleanupIntervalSeconds": 300,
+        "maxConnections": 64,
+        "efConstruction": 128,
+        "vectorCacheMaxObjects": 500000
+      },
+      "vectorIndexType": "hnsw",
+      "vectorizer": "text2vec-transformers"
+    }
+  ]
 }
 ```
 
@@ -5251,8 +5219,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
         }
       }
@@ -5271,11 +5239,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles{
-        ... on Article{
+      hasArticles {
+        ... on Article {
           title
           hasAuthors {
-            ... on Author{
+            ... on Author {
               name
             }
           }
@@ -5288,7 +5256,6 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
-
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5296,11 +5263,7 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where:{
-        operator: GreaterThanEqual
-        path: ["wordCount"]
-        valueInt: 1000
-      }
+      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
       limit: 10
     ) {
       title
@@ -5310,27 +5273,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate{
-    Publication{
-      meta{
+  Aggregate {
+    Publication {
+      meta {
         count
       }
     }
-    Author{
-      meta{
+    Author {
+      meta {
         count
       }
     }
-    Article{
-      meta{
+    Article {
+      meta {
         count
       }
       wordCount {
@@ -5358,20 +5321,15 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(
-      nearText: {
-        concepts: ["money"]
-      }
-      limit: 10
-    ) {
+    Article(nearText: { concepts: ["money"] }, limit: 10) {
       title
       summary
     }
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 You can also combine filters!
 
@@ -5380,20 +5338,13 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: {
-        concepts: ["rideSharing"]
-      }
-      where:{ 
-        operator:And
-        operands: [{
-          operator: GreaterThan
-          path: ["wordCount"]
-          valueInt: 200
-        }, {
-          operator:Like
-          path:["title"]
-          valueString:"*tax*"
-        }]
+      nearText: { concepts: ["rideSharing"] }
+      where: {
+        operator: And
+        operands: [
+          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
+          { operator: Like, path: ["title"], valueString: "*tax*" }
+        ]
       }
       limit: 10
     ) {
@@ -5404,8 +5355,8 @@ You can also combine filters!
   }
 }
 ```
-{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+{% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5415,26 +5366,23 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(
-      group: {
-        type: merge
-        force: 0.1
-      }
-    ) {
+    Publication(group: { type: merge, force: 0.1 }) {
       name
     }
   }
 }
 ```
+
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
-
 # What's next
+
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
+
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
 
 # More resources
 

--- a/developers/weaviate/v1.9.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.9.0/getting-started/quick-start.md
@@ -6,7 +6,7 @@ sub-menu: Getting started
 title: Quick start
 intro: This quick start guide will give you a 10-minute tour of Weaviate. You will set up your Weaviate with Docker, add an example dataset with news articles, make your first queries to browse through your data, and let Weaviate perform automatic classification. This guide uses the "text2vec-tranformers" module. You can find a quick start with the text2vec-contextionary module <a href="../tutorials/quick-start-with-the-text2vec-contextionary-module.html">here</a>.
 description: Get started with Weaviate
-tags: ["quick start"]
+tags: ['quick start']
 menu-order: 1
 open-graph-type: article
 og-img: documentation.jpg
@@ -64,15 +64,14 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
-{% include docs-current_version_finder.html %}
 
 ```json
 {
-  "hostname": "http://[::]:8080",
-  "modules": {
-    "text2vec-transformers": {}
-  },
-  "version": "{{ current_page_version }}"
+    "hostname": "http://[::]:8080",
+    "modules": {
+        "text2vec-transformers": {}
+    },
+    "version": "{{ site.weaviate_version}}"
 }
 ```
 
@@ -88,244 +87,277 @@ The output will look something like this:
 
 ```json
 {
-  "classes": [
-    {
-      "class": "Publication",
-      "description": "A publication with an online source",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
+    "classes": [
+        {
+            "class": "Publication",
+            "description": "A publication with an online source",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the publication",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "geoCoordinates"
+                    ],
+                    "description": "Geo location of the HQ",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "headquartersGeoLocation"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "The articles this publication has",
+                    "name": "hasArticles"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Author",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": true
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "Name of the author",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                },
+                {
+                    "dataType": [
+                        "Article"
+                    ],
+                    "description": "Articles this author wrote",
+                    "name": "wroteArticles"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "The publication this author writes for",
+                    "name": "writesFor"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Article",
+            "description": "Normalised types",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "title of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "title"
+                },
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "url of the article",
+                    "indexInverted": false,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "url"
+                },
+                {
+                    "dataType": [
+                        "text"
+                    ],
+                    "description": "summary of the article",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "summary"
+                },
+                {
+                    "dataType": [
+                        "date"
+                    ],
+                    "description": "date of publication of the article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "publicationDate"
+                },
+                {
+                    "dataType": [
+                        "int"
+                    ],
+                    "description": "Words in this article",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "wordCount"
+                },
+                {
+                    "dataType": [
+                        "boolean"
+                    ],
+                    "description": "whether the article is currently accessible through the url",
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "isAccessible"
+                },
+                {
+                    "dataType": [
+                        "Author",
+                        "Publication"
+                    ],
+                    "description": "authors this article has",
+                    "name": "hasAuthors"
+                },
+                {
+                    "dataType": [
+                        "Publication"
+                    ],
+                    "description": "publication this article is in",
+                    "name": "inPublication"
+                },
+                {
+                    "dataType": [
+                        "Category"
+                    ],
+                    "description": "category this article is of",
+                    "name": "ofCategory"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
+        },
+        {
+            "class": "Category",
+            "description": "Category an article is a type off",
+            "invertedIndexConfig": {
+                "cleanupIntervalSeconds": 60
+            },
+            "moduleConfig": {
+                "text2vec-transformers": {
+                    "poolingStrategy": "masked_mean",
+                    "vectorizeClassName": false
+                }
+            },
+            "properties": [
+                {
+                    "dataType": [
+                        "string"
+                    ],
+                    "description": "category name",
+                    "indexInverted": true,
+                    "moduleConfig": {
+                        "text2vec-transformers": {
+                            "skip": false,
+                            "vectorizePropertyName": false
+                        }
+                    },
+                    "name": "name"
+                }
+            ],
+            "vectorIndexConfig": {
+                "cleanupIntervalSeconds": 300,
+                "maxConnections": 64,
+                "efConstruction": 128,
+                "vectorCacheMaxObjects": 500000
+            },
+            "vectorIndexType": "hnsw",
+            "vectorizer": "text2vec-transformers"
         }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the publication",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["geoCoordinates"],
-          "description": "Geo location of the HQ",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "headquartersGeoLocation"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "The articles this publication has",
-          "name": "hasArticles"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Author",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": true
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "Name of the author",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        },
-        {
-          "dataType": ["Article"],
-          "description": "Articles this author wrote",
-          "name": "wroteArticles"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "The publication this author writes for",
-          "name": "writesFor"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Article",
-      "description": "Normalised types",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "title of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "title"
-        },
-        {
-          "dataType": ["string"],
-          "description": "url of the article",
-          "indexInverted": false,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "url"
-        },
-        {
-          "dataType": ["text"],
-          "description": "summary of the article",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "summary"
-        },
-        {
-          "dataType": ["date"],
-          "description": "date of publication of the article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "publicationDate"
-        },
-        {
-          "dataType": ["int"],
-          "description": "Words in this article",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "wordCount"
-        },
-        {
-          "dataType": ["boolean"],
-          "description": "whether the article is currently accessible through the url",
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "isAccessible"
-        },
-        {
-          "dataType": ["Author", "Publication"],
-          "description": "authors this article has",
-          "name": "hasAuthors"
-        },
-        {
-          "dataType": ["Publication"],
-          "description": "publication this article is in",
-          "name": "inPublication"
-        },
-        {
-          "dataType": ["Category"],
-          "description": "category this article is of",
-          "name": "ofCategory"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    },
-    {
-      "class": "Category",
-      "description": "Category an article is a type off",
-      "invertedIndexConfig": {
-        "cleanupIntervalSeconds": 60
-      },
-      "moduleConfig": {
-        "text2vec-transformers": {
-          "poolingStrategy": "masked_mean",
-          "vectorizeClassName": false
-        }
-      },
-      "properties": [
-        {
-          "dataType": ["string"],
-          "description": "category name",
-          "indexInverted": true,
-          "moduleConfig": {
-            "text2vec-transformers": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "name"
-        }
-      ],
-      "vectorIndexConfig": {
-        "cleanupIntervalSeconds": 300,
-        "maxConnections": 64,
-        "efConstruction": 128,
-        "vectorCacheMaxObjects": 500000
-      },
-      "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-transformers"
-    }
-  ]
+    ]
 }
 ```
 
@@ -5219,8 +5251,8 @@ You can also find which articles are related to these publications.
   Get {
     Publication {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
         }
       }
@@ -5239,11 +5271,11 @@ And you can even go deeper, to find which authors are related to these publicati
   Get {
     Publication(limit: 3) {
       name
-      hasArticles {
-        ... on Article {
+      hasArticles{
+        ... on Article{
           title
           hasAuthors {
-            ... on Author {
+            ... on Author{
               name
             }
           }
@@ -5256,6 +5288,7 @@ And you can even go deeper, to find which authors are related to these publicati
 
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28limit%3A+3%29+%7B%0D%0A++++++name%0D%0A++++++hasArticles%7B%0D%0A++++++++...+on+Article%7B%0D%0A++++++++++title%0D%0A++++++++++hasAuthors+%7B%0D%0A++++++++++++...+on+Author%7B%0D%0A++++++++++++++name%0D%0A++++++++++++%7D%0D%0A++++++++++%7D%0D%0A++++++++%7D%0D%0A++++++%7D%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
 
+
 When querying for articles, you can also add classic filters to narrow down your search.
 
 ```graphql
@@ -5263,7 +5296,11 @@ When querying for articles, you can also add classic filters to narrow down your
 {
   Get {
     Article(
-      where: { operator: GreaterThanEqual, path: ["wordCount"], valueInt: 1000 }
+      where:{
+        operator: GreaterThanEqual
+        path: ["wordCount"]
+        valueInt: 1000
+      }
       limit: 10
     ) {
       title
@@ -5273,27 +5310,27 @@ When querying for articles, you can also add classic filters to narrow down your
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++where%3A%7B%0D%0A++++++++operator%3A+GreaterThanEqual%0D%0A++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++valueInt%3A+1000%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Do you want to know how many articles, authors and publications there are? This is something you can find using the Aggregate{} function.
 
 ```graphql
 # GraphQL
 {
-  Aggregate {
-    Publication {
-      meta {
+  Aggregate{
+    Publication{
+      meta{
         count
       }
     }
-    Author {
-      meta {
+    Author{
+      meta{
         count
       }
     }
-    Article {
-      meta {
+    Article{
+      meta{
         count
       }
       wordCount {
@@ -5321,15 +5358,20 @@ In Weaviate, you can also semantically explore your datasets. Let's search for a
 # GraphQL
 {
   Get {
-    Article(nearText: { concepts: ["money"] }, limit: 10) {
+    Article(
+      nearText: {
+        concepts: ["money"]
+      }
+      limit: 10
+    ) {
       title
       summary
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22money%22%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 You can also combine filters!
 
@@ -5338,13 +5380,20 @@ You can also combine filters!
 {
   Get {
     Article(
-      nearText: { concepts: ["rideSharing"] }
-      where: {
-        operator: And
-        operands: [
-          { operator: GreaterThan, path: ["wordCount"], valueInt: 200 }
-          { operator: Like, path: ["title"], valueString: "*tax*" }
-        ]
+      nearText: {
+        concepts: ["rideSharing"]
+      }
+      where:{ 
+        operator:And
+        operands: [{
+          operator: GreaterThan
+          path: ["wordCount"]
+          valueInt: 200
+        }, {
+          operator:Like
+          path:["title"]
+          valueString:"*tax*"
+        }]
       }
       limit: 10
     ) {
@@ -5355,8 +5404,8 @@ You can also combine filters!
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Article%28%0D%0A++++++nearText%3A+%7B%0D%0A++++++++concepts%3A+%5B%22rideSharing%22%5D%0D%0A++++++%7D%0D%0A++++++where%3A%7B+%0D%0A++++++++operator%3AAnd%0D%0A++++++++operands%3A+%5B%7B%0D%0A++++++++++operator%3A+GreaterThan%0D%0A++++++++++path%3A+%5B%22wordCount%22%5D%0D%0A++++++++++valueInt%3A+200%0D%0A++++++++%7D%2C+%7B%0D%0A++++++++++operator%3ALike%0D%0A++++++++++path%3A%5B%22title%22%5D%0D%0A++++++++++valueString%3A%22%2Atax%2A%22%0D%0A++++++++%7D%5D%0D%0A++++++%7D%0D%0A++++++limit%3A+10%0D%0A++++%29+%7B%0D%0A++++++title%0D%0A++++++summary%0D%0A++++++wordCount%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D' %}
+
 
 Or group similar topics semantically together. Look how the Publications `International New York Times`, `The New York Times Company` and `New York Times` are merged.
 
@@ -5366,23 +5415,26 @@ _Tip: play around with the force variable._
 # GraphQL
 {
   Get {
-    Publication(group: { type: merge, force: 0.1 }) {
+    Publication(
+      group: {
+        type: merge
+        force: 0.1
+      }
+    ) {
       name
     }
   }
 }
 ```
-
 {% include molecule-gql-demo.html encoded_query='%7B%0D%0A++Get+%7B%0D%0A++++Publication%28%0D%0A++++++group%3A+%7B%0D%0A++++++++type%3A+merge%0D%0A++++++++force%3A+0.1%0D%0A++++++%7D%0D%0A++++%29+%7B%0D%0A++++++name%0D%0A++++%7D%0D%0A++%7D%0D%0A%7D%0D%0A' %}
 
+
 # What's next
-
 In this tutorial you learned about how to quickly set up a Weaviate with a demo dataset, use semantic search and classification. Next, check out the following:
-
 - Check out how to [spin up a Weaviate](./installation.html) with your own [schema](../tutorials/how-to-create-a-schema.html) and [data](../tutorials/how-to-import-data.html).
 - Learn more about [authentication](../configuration/authentication.html) and [authorization](../configuration/authorization.html).
 - Install one of the [client libraries](../client-libraries/index.html) for smooth interaction with the Weaviate APIs.
-- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate.
+- Consult the [RESTful API references](../restful-api-references/index.html) and the [GraphQL references](../graphql-references/index.html) to learn about all interaction possibilities with Weaviate. 
 
 # More resources
 

--- a/developers/weaviate/v1.9.0/getting-started/quick-start.md
+++ b/developers/weaviate/v1.9.0/getting-started/quick-start.md
@@ -64,6 +64,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look something like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -71,7 +72,7 @@ The output will look something like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 


### PR DESCRIPTION
Fixes: #103 

So, in `quick-start.md` file of every version, the version present in the example didn't match the configuration. This problem was caused due to variable `weaviate_version` which had hard-coded value of `v1.12.1`. This caused all the pages to show fix version.

Workaround for this was to include `{% include docs-current_version_finder.html %}` this tag, which identified current version of the page and call the variable `current_page_version` in front of `version` key. 

## Before
v1.11.0
![Screenshot (275)](https://user-images.githubusercontent.com/81866614/165109466-a300e0a0-c0c0-41a5-82de-e22f1db6abe9.png)

v1.0.4
![Screenshot (276)](https://user-images.githubusercontent.com/81866614/165109532-cee30bf3-26dd-47a4-8248-b2afd604a567.png)

## After
v1.11.0
![Screenshot from 2022-04-25 19-29-26](https://user-images.githubusercontent.com/81866614/165109578-22049c3b-eb39-4302-90f4-a5042d652e2d.png)

v1.0.4
![Screenshot from 2022-04-25 19-30-45](https://user-images.githubusercontent.com/81866614/165109612-7c813a2f-3a8a-43cd-b3fc-66d889cd33ac.png)

