### PR TITLE
missing /objects/ in tutorial uri

### DIFF
--- a/developers/weaviate/v1.11.0/tutorials/how-to-perform-a-semantic-search.md
+++ b/developers/weaviate/v1.11.0/tutorials/how-to-perform-a-semantic-search.md
@@ -104,13 +104,13 @@ As you can see, the same arguments are applied in the "explore" filter and the `
 If you are interested in property values of the returned objects, you will need to do a second query to to retrieve data of the beacon:
 
 ```bash
-$ curl -s http://localhost:8080/v1/{id}
+$ curl -s http://localhost:8080/v1/objects/{id}
 ```
 
 So querying all property values of the first result can be done as follows:
 
 ```bash
-$ curl -s http://localhost:8080/v1/65010df4-da64-333d-b1ce-55c3fc9174ab
+$ curl -s http://localhost:8080/v1/objects/65010df4-da64-333d-b1ce-55c3fc9174ab
 ```
 
 # Next steps


### PR DESCRIPTION
There was a part of the uri missing in [this](https://weaviate.io/developers/weaviate/v1.11.0/tutorials/how-to-perform-a-semantic-search.html#explore-graphql-function) tutorial in the final part of the "explore graphql" section
Before:
`$ curl -s http://localhost:8080/v1/{id}
`

After:
`$ curl -s http://localhost:8080/v1/objects/{id}
`
This was discussed in [this issue](https://github.com/semi-technologies/weaviate-io/issues/114)