### PR TITLE
fix: remove v0.23 from dropdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,8 +65,6 @@ weaviate_versions: # order the versions how you want them displayed
     helm_version: 12.0.0 # Helm version for this Weaviate version
   "v1.0.4":
     helm_version: 12.0.0 # Helm version for this Weaviate version
-  "0.23.2":
-    helm_version: 11.0.0 # Helm version for this Weaviate version
 docs:
   weaviate:
     "v1.12.2":


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

As I was browsing through various versions from dropdown, I noticed docs for version 0.23 doesn't exist. I checked current files and folder and there wasn't any doc present for that version

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

Removed just the version 0.23 from version dropdown list

#### Before 
![Screenshot from 2022-05-03 11-14-32](https://user-images.githubusercontent.com/81866614/166409720-2e3a4024-ce7c-4898-9435-715352f31fa7.png)

#### After
![Screenshot from 2022-05-03 11-14-24](https://user-images.githubusercontent.com/81866614/166409745-1c75210e-4045-4455-9f4e-70dff77e837d.png)

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

Tested by running the site locally. 

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
