### PR TITLE
fix: improve buildtime

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,9 @@ exclude:
   - LICENSE.md
   - "*.rb"
   - .github/
+  - .jekyll-cache
+keep_files:
+  - img
 plugins:
   - jekyll-redirect-from
   - jekyll-toc


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

The site was taking way too long to build. I researched about a few ways for optimising the build and made a few changes in `_config.yml` file.

### What's being changed:

Added `.jekyll-cache` in `exclude` key. This folder is not required for Jekyll to build the site.

Added `keep_files` key and assigned it with `img` value. This keeps the files as is. Jekyll has nothing to do with those images. Static files that do not need any Jekyll intervention can be kept as-is using this parameter in the configuration. It instructs Jekyll to not remove `img`  folder when clearing the site output directory on every build.
<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] Feature or enhancements (non-breaking change which adds functionality)

### How Has This Been Tested?

The site has been tested locally and the build time reduced for me by around 95 seconds.
<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
