### PR TITLE
fix: version number on quickstart

### DIFF
--- a/developers/weaviate/v1.12.2/getting-started/quick-start.md
+++ b/developers/weaviate/v1.12.2/getting-started/quick-start.md
@@ -67,6 +67,7 @@ $ curl -s http://localhost:8080/v1/meta
 ```
 
 The output will look like this:
+{% include docs-current_version_finder.html %}
 
 ```json
 {
@@ -74,7 +75,7 @@ The output will look like this:
     "modules": {
         "text2vec-transformers": {}
     },
-    "version": "{{ site.weaviate_version}}"
+    "version": "{{ current_page_version }}"
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

I was browsing through different versions and noticed that v1.12.2 had v1.13.1 hardcoded due to yml file specification. Fixed that error by including current page version.

## Screenshots

### Before
![Screenshot from 2022-05-07 13-14-45](https://user-images.githubusercontent.com/81866614/167244839-d9de385d-42cb-42f8-b81f-b6e7370835b3.png)

### After
![Screenshot from 2022-05-07 13-14-53](https://user-images.githubusercontent.com/81866614/167244849-3c05e6d2-724d-461f-b4a8-8068abaad897.png)


### Type of change:

<!--Please delete options that are not relevant.-->

- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

This has been tested locally.

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
