### PR TITLE
docs: fix incorrect path

### DIFF
--- a/_includes/code/1.x/howto.add.data.things.add.reference.html
+++ b/_includes/code/1.x/howto.add.data.things.add.reference.html
@@ -170,7 +170,7 @@ $ curl \
     -d '{
       "beacon": "weaviate://localhost/f81bfe5e-16ba-4615-a516-46c2ae2e5a80"
   }' \
-    http://localhost:8080/v1/36ddd591-2dee-4e7e-a3cc-eb86d30a4303/references/writesFor
+    http://localhost:8080/v1/objects/36ddd591-2dee-4e7e-a3cc-eb86d30a4303/references/writesFor
 {% endcapture %}
 
 {% include molecule-restful-block-request.html block_id='howto-add-data-things-reference' %}


### PR DESCRIPTION
### Why:
Fixes url in docs

### What's being changed:
Url fix in docs

### Type of change:
- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

Compare curls of old and new URL below

Old url:
```
curl -POST http://localhost:8086/v1/8b0f98b0-4765-5426-89d5-18979ca0bbeb/references/contributors -H 'Content-Type: application/json' --data '{"beacon": "weaviate://localhost/69fac978-ede7-5db2-b74e-bab2d6347d20"}' -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8086 (#0)
> POST /v1/8b0f98b0-4765-5426-89d5-18979ca0bbeb/references/contributors HTTP/1.1
> Host: localhost:8086
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 71
>
* upload completely sent off: 71 out of 71 bytes
< HTTP/1.1 404 Not Found
< Content-Type: application/json
< Vary: Origin
< Date: Fri, 27 May 2022 11:46:35 GMT
< Content-Length: 108
<
* Connection #0 to host localhost left intact
{"code":404,"message":"path /v1/8b0f98b0-4765-5426-89d5-18979ca0bbeb/references/contributors was not found"}* Closing connection 0
```
New url:
```
 curl -POST http://localhost:8086/v1/objects/8b0f98b0-4765-5426-89d5-18979ca0bbeb/references/contributors -H 'Content-Type: application/json' --data '{"beacon": "weaviate://localhost/69fac978-ede7-5db2-b74e-bab2d6347d20"}' -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8086 (#0)
> POST /v1/objects/8b0f98b0-4765-5426-89d5-18979ca0bbeb/references/contributors HTTP/1.1
> Host: localhost:8086
> User-Agent: curl/7.64.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 71
>
* upload completely sent off: 71 out of 71 bytes
< HTTP/1.1 200 OK
< Vary: Origin
< Date: Fri, 27 May 2022 11:47:15 GMT
< Content-Length: 0
<
* Connection #0 to host localhost left intact
* Closing connection 0
```

