### PR TITLE
Update how-to-perform-a-semantic-search.md

### DIFF
--- a/developers/weaviate/current/tutorials/how-to-perform-a-semantic-search.md
+++ b/developers/weaviate/current/tutorials/how-to-perform-a-semantic-search.md
@@ -104,13 +104,13 @@ As you can see, the same arguments are applied in the "explore" filter and the `
 If you are interested in property values of the returned objects, you will need to do a second query to to retrieve data of the beacon:
 
 ```bash
-$ curl -s http://localhost:8080/v1/{id}
+$ curl -s http://localhost:8080/v1/objects/{id}
 ```
 
 So querying all property values of the first result can be done as follows:
 
 ```bash
-$ curl -s http://localhost:8080/v1/65010df4-da64-333d-b1ce-55c3fc9174ab
+$ curl -s http://localhost:8080/v1/objects/65010df4-da64-333d-b1ce-55c3fc9174ab
 ```
 
 # Next steps


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

The curl command given for retrieving data of the beacon returns a 404 error.
It should be replaced with 
```bash
$ curl -s http://localhost:8080/v1/objects/{id}
```

### What's being changed:
```bash
$ curl -s http://localhost:8080/v1/{id}
```

So querying all property values of the first result can be done as follows:

```bash
$ curl -s http://localhost:8080/v1/65010df4-da64-333d-b1ce-55c3fc9174ab
```

to 

```bash
$ curl -s http://localhost:8080/v1/objects/{id}
```

So querying all property values of the first result can be done as follows:

```bash
$ curl -s http://localhost:8080/v1/objects/65010df4-da64-333d-b1ce-55c3fc9174ab
```

### Type of change:

<!--Please delete options that are not relevant.-->
- Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?
![Screenshot from 2022-06-22 04-13-47](https://user-images.githubusercontent.com/75658681/174909606-354cbe8f-1202-43c6-b36e-8b3790609448.png)

On trying to retrieve data of the first beacon, The given curl command throws a 404 error

![image](https://user-images.githubusercontent.com/75658681/174909774-59db22ac-c327-41b1-a3c3-c8a49755be40.png)

But gives the required output with command
```bash
$ curl -s http://localhost:8080/v1/objects/{id}
```

![image](https://user-images.githubusercontent.com/75658681/174909876-5ed09b84-f624-4892-9b38-09c4ce7d7cda.png)

