### PR TITLE
Fix typo in getting started docker-compose example

### DIFF
--- a/developers/weaviate/current/getting-started/installation.md
+++ b/developers/weaviate/current/getting-started/installation.md
@@ -66,7 +66,7 @@ services:
       DEFAULT_VECTORIZER_MODULE: text2vec-transformers
       ENABLE_MODULES: text2vec-transformers
       TRANSFORMERS_INFERENCE_API: http://t2v-transformers:8080
-      CLUSTER_HOSTNAME: 'node1
+      CLUSTER_HOSTNAME: 'node1'
   t2v-transformers:
     image: semitechnologies/transformers-inference:sentence-transformers-msmarco-distilroberta-base-v2
     environment:


### PR DESCRIPTION
### Why:

This PR fixes: typo in developers/weaviate/current/getting-started/installation.md, where a `'` is missing in the docker-compose.yml example

### What's being changed:

added a  `'`

### Type of change:

- [x ] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

copy the docker-compose.yml example from the mentioned file and try to start it. Didn't work before, works now