### PR TITLE
Fix branching logic in first java example

### DIFF
--- a/developers/weaviate/current/client-libraries/java.md
+++ b/developers/weaviate/current/client-libraries/java.md
@@ -37,7 +37,7 @@ public class App {
     Config config = new Config("http", "localhost:8080");
     WeaviateClient client = new WeaviateClient(config);
     Result<Meta> meta = client.misc().metaGetter().run();
-    if (meta.getError() != null) {
+    if (meta.getError() == null) {
       System.out.printf("meta.hostname: %s\n", meta.getResult().getHostname());
       System.out.printf("meta.version: %s\n", meta.getResult().getVersion());
       System.out.printf("meta.modules: %s\n", meta.getResult().getModules());


### PR DESCRIPTION


<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

This PR fixes an issue discovered when trying to follow the documentation on how to connect to weaviate using the java client library.

### What's being changed:

The branching logic of the first java example on line 40 was backwards using weaviate 1.14.1 and the 3.2.0 java client library. This fixes things and the meta info on the running instance is reported properly.

Before this change I hit the code on line 45 which caused a null pointer exception because meta.getError() returns null in the non-error case.

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

The changed code was pulled from my proof-of-concept application which first broken when using the original documentation example but works using the one-line change.
