### PR TITLE
update schema for vectorizers

### DIFF
--- a/developers/weaviate/current/retriever-vectorizer-modules/img2vec-neural.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/img2vec-neural.md
@@ -139,44 +139,45 @@ A full example of a class using the `img2vec-neural` module is shown below. This
 
 ```json
 {
-    "classes": [{
-        "class": "FashionItem",
-        "description": "Each example is a 28x28 grayscale image, associated with a label from 10 classes.",
-        "moduleConfig": {
-            "img2vec-neural": {
-                "imageFields": [
-                    "image"
-                ]
-            }
+  "classes": [
+    {
+      "class": "FashionItem",
+      "description": "Each example is a 28x28 grayscale image, associated with a label from 10 classes.",
+      "moduleConfig": {
+        "img2vec-neural": {
+          "imageFields": [
+            "image"
+          ]
+        }
+      },
+      "properties": [
+        {
+          "dataType": [
+            "blob"
+          ],
+          "description": "Grayscale image",
+          "name": "image"
         },
-        "properties": [
-            {
-                "dataType": [
-                    "blob"
-                ],
-                "description": "Grayscale image",
-                "name": "image"
-            },
-            {
-                "dataType": [
-                    "number"
-                ],
-                "description": "Label number for the given image.",
-                "name": "labelNumber"
-            },
-            {
-                "dataType": [
-                    "string"
-                ],
-                "description": "label name (description) of the given image.",
-                "name": "labelName"
-            }
-
-        ],
-
-        "vectorIndexType": "hnsw",
-        "vectorizer": "img2vec-neural"
-    }]}
+        {
+          "dataType": [
+            "number"
+          ],
+          "description": "Label number for the given image.",
+          "name": "labelNumber"
+        },
+        {
+          "dataType": [
+            "string"
+          ],
+          "description": "label name (description) of the given image.",
+          "name": "labelName"
+        }
+      ],
+      "vectorIndexType": "hnsw",
+      "vectorizer": "img2vec-neural"
+    }
+  ]
+}
 ```
 
 _Note:_ Other properties, for example the name of the image that is given in another field, will not be taken into consideration. This means that you can only find the image with semantic search by [another image](#nearimage-search), [data object](../graphql-references/filters.html#nearobject-filter), or [raw vector](../graphql-references/filters.html#nearvector-filter). Semantic search of images by text field (using `nearText`) is not possible, because this requires a `text2vec` vectorization module. Multiple modules cannot be combined at class level yet (might become possible in the future, since `image-text-combined transformers` exists). We recommend to use one of the following workarounds:

--- a/developers/weaviate/current/retriever-vectorizer-modules/multi2vec-clip.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/multi2vec-clip.md
@@ -168,35 +168,39 @@ text fields using the `multi2vec-clip` module as a `vectorizer`:
 
 ```json
 {
-  "class": "ClipExample",
-  "moduleConfig": {
-      "multi2vec-clip": {
+  "classes": [
+    {
+      "class": "ClipExample",
+      "moduleConfig": {
+        "multi2vec-clip": {
           "imageFields": [
-              "image"
+            "image"
           ],
           "textFields": [
-              "name"
+            "name"
           ],
           "weights": {
             "textFields": [0.7],
             "imageFields": [0.3]
           }
-      }
-  },
-  "vectorIndexType": "hnsw",
-  "vectorizer": "multi2vec-clip",
-  "properties": [
-    {
-      "dataType": [
-        "string"
+        }
+      },
+      "properties": [
+        {
+          "dataType": [
+            "string"
+          ],
+          "name": "name"
+        },
+        {
+          "dataType": [
+            "blob"
+          ],
+          "name": "image"
+        }
       ],
-      "name": "name"
-    },
-    {
-      "dataType": [
-          "blob"
-      ],
-      "name": "image"
+      "vectorIndexType": "hnsw",
+      "vectorizer": "multi2vec-clip"
     }
   ]
 }

--- a/developers/weaviate/current/retriever-vectorizer-modules/text2vec-contextionary.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/text2vec-contextionary.md
@@ -129,7 +129,8 @@ For example
           },
           "name": "content"
         }
-      ]
+      ],
+      "vectorizer": "text2vec-contextionary"
     }
   ]
 }

--- a/developers/weaviate/current/retriever-vectorizer-modules/text2vec-openai.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/text2vec-openai.md
@@ -88,7 +88,8 @@ The following schema configuration uses the `babbage` model.
           },
           "name": "content"
         }
-      ]
+      ],
+      "vectorizer": "text2vec-openai"
     }
   ]
 }

--- a/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.md
@@ -215,7 +215,8 @@ For example:
           },
           "name": "content"
         }
-      ]
+      ],
+      "vectorizer": "text2vec-transformers"
     }
   ]
 }


### PR DESCRIPTION
### Why:

Some of the vectorizers were missing `vectorizer` property, which is required to define a class schema.

### What's being changed:

Updated schema examples for vectorizers.

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

Local build
