### PR TITLE
updates related to DefaultVectorCacheMaxObjects

### DIFF
--- a/developers/weaviate/current/architecture/resources.md
+++ b/developers/weaviate/current/architecture/resources.md
@@ -21,9 +21,8 @@ a role.
 
 Note that Weaviate has an option to limit the amount of vectors held in memory
 to prevent unexpected Out-of-Memory ("OOM") situations. This limit is entirely
-configurable and by default is set to 2M objects per class. If your import
-performance drops drastically after reaching 2M objects, see section [Vector
-Cache](#vector-cache) below.
+configurable and by default is set to `math.MaxInt64` (i.e., `9223372036854775807`)
+objects per class.
 
 # The role of CPUs 
 
@@ -163,8 +162,8 @@ requirements:
 For optimal search and import performance, all previously imported vectors need
 to be held in memory. However, Weaviate also allows for limiting the number of
 vectors in memory. By default, when creating a new class, this limit is set to
-2M objects. A disk lookup for a vector is orders of magnitudes slower than
-memory lookup, so the cache should be used sparingly.
+`math.MaxInt64` (i.e., `9223372036854775807`) objects. A disk lookup for a vector
+is orders of magnitudes slower than memory lookup, so the cache should be used sparingly.
 
 Generally we recommend that:
 - During imports, set the limit so that all vectors can be held in memory. Each
@@ -180,14 +179,6 @@ Generally we recommend that:
   have a large dataset, but a large percentage of users only query a specific
   subset of vectors. In this case, you might be able to serve the largest user
   group from cache while requiring disk lookups for "irregular" queries.
-
-## Imports slowed down after crossing ~2M objects - what can I do?
-
-If you notice that your import performance drops drastically after the 2M
-objects (per class) mark, you are most likely running into the default 2M limit
-of the vector cache. You can [adjust the limit on existing
-classes](../vector-index-plugins/hnsw.html#how-to-use-hnsw-and-parameters)
-without having to recreate the class or reimport.
 
 # The role of GPUs in Weaviate
 

--- a/developers/weaviate/current/architecture/resources.md
+++ b/developers/weaviate/current/architecture/resources.md
@@ -21,7 +21,7 @@ a role.
 
 Note that Weaviate has an option to limit the amount of vectors held in memory
 to prevent unexpected Out-of-Memory ("OOM") situations. This limit is entirely
-configurable and by default is set to `math.MaxInt64` (i.e., `9223372036854775807`)
+configurable and by default is set to one trillion (i.e. `1e12`)
 objects per class.
 
 # The role of CPUs 
@@ -162,7 +162,7 @@ requirements:
 For optimal search and import performance, all previously imported vectors need
 to be held in memory. However, Weaviate also allows for limiting the number of
 vectors in memory. By default, when creating a new class, this limit is set to
-`math.MaxInt64` (i.e., `9223372036854775807`) objects. A disk lookup for a vector
+one trillion (i.e. `1e12`) objects. A disk lookup for a vector
 is orders of magnitudes slower than memory lookup, so the cache should be used sparingly.
 
 Generally we recommend that:

--- a/developers/weaviate/current/core-knowledge/indexing.md
+++ b/developers/weaviate/current/core-knowledge/indexing.md
@@ -69,7 +69,7 @@ We have a dedicated section containing all the [vector index settings](../vector
 * `vectorIndexType` is the ANN algorithm you want to use. By default, Weaviate selects `hnsw` -- the Hierarchical Navigable Small World (HNSW) algorithm.
 * `ef` is HNSW specific, and is used to find the right vectors stored in the index. The higher you set it the more accurate the recall but the slower the search becomes (more about picking the right index strategy below). By default Weaviate sets the value to `-1` which means as much as: "Let Weaviate pick the right ef value for me."
 * `efConstruction` is HNSW specific, you can't change it after creating the class (i.e., it is immutable) but it mitigates the above-mentioned `ef` settings. The tradeoff here is on importing. So a high `efConstruction` means that you can lower your `ef` settings but that importing will be slower.
-* `vectorCacheMaxObjects` is the Weaviate cache. By default it is set to 2,000,000. We would recommend setting this to a number _greater_ than your total object amount.
+* `vectorCacheMaxObjects` is the Weaviate cache. By default it is set to one trillion (i.e. `1e12`). We recommend setting this to a number _greater_ than your total object amount.
 * `distance` is the type of distance calculation in vector space, for most machine learning models cosine similatiry, is the distance metric that we need, but Weaviate does [support other distance metrics as well](../vector-index-plugins/distances.html).
 
 Now you might be wondering: "What settings do I need for my use case?"

--- a/developers/weaviate/current/restful-api-references/batch.md
+++ b/developers/weaviate/current/restful-api-references/batch.md
@@ -30,7 +30,7 @@ A few points to bear in mind:
 0. If you use a vectorizer that improves with GPU support, make sure to enable it if possible, it will drastically improve import.
 0. Avoid duplicate vectors for multiple data objects.
 0. Handle your errors, if you ignore them, it might lead to significant delays on import.
-0. If import slows down after 2M objects, consider setting the [`vectorCacheMaxObjects`](/developers/weaviate/current/vector-index-plugins/hnsw.html) in your schema. Also, see [this example](https://github.com/semi-technologies/semantic-search-through-wikipedia-with-weaviate/blob/d4711f2bdc75afd503ff70092c3c5303f9dd1b3b/step-2/import.py#L58-L59).
+0. If import slows down after a particular number of objects (e.g. 2M), check to see if the [`vectorCacheMaxObjects`](/developers/weaviate/current/vector-index-plugins/hnsw.html) in your schema is larger than the number of objects. Also, see [this example](https://github.com/semi-technologies/semantic-search-through-wikipedia-with-weaviate/blob/d4711f2bdc75afd503ff70092c3c5303f9dd1b3b/step-2/import.py#L58-L59).
 0. There are ways to improve your setup when using vectorizers. Like in the Wikipedia demo dataset. We will keep publishing about this, sign up for our [Slack channel]({{ site.slack_signup_url }}) to keep up to date.
 
 ### Method and URL

--- a/developers/weaviate/current/vector-index-plugins/hnsw.md
+++ b/developers/weaviate/current/vector-index-plugins/hnsw.md
@@ -57,7 +57,7 @@ Currently the only index type is HNSW, so all data objects will be indexed using
     between the lower and upper boundary. It will be capped on either end,
     otherwise. *Not available prior to `v1.10.0`. Defaults to `8`. This setting
     has no effect if `ef` has a value other than `-1`.*
-  - `"vectorCacheMaxObjects"`: For optimal search and import performance all previously imported vectors need to be held in memory. However, Weaviate also allows for limiting the number of vectors in memory. By default, when creating a new class, this limit is set to `math.MaxInt64` (i.e., `9223372036854775807`) objects. A disk lookup for a vector is orders of magnitudes slower than memory lookup, so the cache should be used sparingly. This field is mutable after initially creating the class.
+  - `"vectorCacheMaxObjects"`: For optimal search and import performance all previously imported vectors need to be held in memory. However, Weaviate also allows for limiting the number of vectors in memory. By default, when creating a new class, this limit is set to one trillion (i.e. `1e12`) objects. A disk lookup for a vector is orders of magnitudes slower than memory lookup, so the cache should be used sparingly. This field is mutable after initially creating the class.
   Generally we recommend that:
     - During imports set the limit so that all vectors can be held in memory. Each
       import requires multiple searches so import performance will drop drastically

--- a/developers/weaviate/current/vector-index-plugins/hnsw.md
+++ b/developers/weaviate/current/vector-index-plugins/hnsw.md
@@ -57,7 +57,7 @@ Currently the only index type is HNSW, so all data objects will be indexed using
     between the lower and upper boundary. It will be capped on either end,
     otherwise. *Not available prior to `v1.10.0`. Defaults to `8`. This setting
     has no effect if `ef` has a value other than `-1`.*
-  - `"vectorCacheMaxObjects"`: For optimal search and import performance all previously imported vectors need to be held in memory. However, Weaviate also allows for limiting the number of vectors in memory. By default, when creating a new class, this limit is set to 2M objects. A disk lookup for a vector is orders of magnitudes slower than memory lookup, so the cache should be used sparingly. This field is mutable after initially creating the class.
+  - `"vectorCacheMaxObjects"`: For optimal search and import performance all previously imported vectors need to be held in memory. However, Weaviate also allows for limiting the number of vectors in memory. By default, when creating a new class, this limit is set to `math.MaxInt64` (i.e., `9223372036854775807`) objects. A disk lookup for a vector is orders of magnitudes slower than memory lookup, so the cache should be used sparingly. This field is mutable after initially creating the class.
   Generally we recommend that:
     - During imports set the limit so that all vectors can be held in memory. Each
       import requires multiple searches so import performance will drop drastically


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

An update related to: `DefaultVectorCacheMaxObjects` update in Weaviate

### Type of change:

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature or enhancements (non-breaking change which adds functionality)
- [x] Documentation updates (non-breaking change which updates documents)
