### PR TITLE
text2vec-openai: move "vectorizer" above "moduleConfig"

### DIFF
--- a/developers/weaviate/current/retriever-vectorizer-modules/text2vec-openai.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/text2vec-openai.md
@@ -70,6 +70,7 @@ The following schema configuration uses the `babbage` model.
     {
       "class": "Document",
       "description": "A class called document",
+      "vectorizer": "text2vec-openai",
       "moduleConfig": {
         "text2vec-openai": {
           "model": "babbage",
@@ -90,8 +91,7 @@ The following schema configuration uses the `babbage` model.
           },
           "name": "content"
         }
-      ],
-      "vectorizer": "text2vec-openai"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### What's being changed:

Move `vectorizer` right before `moduleConfig`, to match the property order at [Schema configuration -> Class object](https://weaviate.io/developers/weaviate/current/schema/schema-configuration.html#class-object).

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)
