### PR TITLE
Add reference to BACKUP_GCS_BUCKET

### DIFF
--- a/developers/weaviate/current/configuration/backups.md
+++ b/developers/weaviate/current/configuration/backups.md
@@ -109,6 +109,7 @@ In addition to activating the module, you need to provide configuration:
 
 | Environment variable | Required | Description |
 | --- | --- | --- |
+| `BACKUP_GCS_BUCKET` | yes | The name of the GCS bucket for backups. |
 | `BACKUP_GCS_PATH` | no | The root path inside your bucket that all your backups will be copied into and retrieved from. Optional, defaults to `""` which means that the backups will be stored in the bucket root instead of a sub-folder. |
 
 ### Google Application Default Credentials


### PR DESCRIPTION
### Why:

Add reference to required `BACKUP_GCS_BUCKET` environment variable for GCS

### Type of change:

- [X] Documentation updates (non-breaking change which updates documents)
