### PR TITLE
v1.16 go client v5

### DIFF
--- a/_includes/code/1.x/backup.create.html
+++ b/_includes/code/1.x/backup.create.html
@@ -40,8 +40,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/backup"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/backup"
 )
 
 func main() {

--- a/_includes/code/1.x/backup.get.html
+++ b/_includes/code/1.x/backup.get.html
@@ -28,8 +28,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/backup"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/backup"
 )
 
 func main() {

--- a/_includes/code/1.x/backup.restore.html
+++ b/_includes/code/1.x/backup.restore.html
@@ -40,8 +40,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/backup"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/backup"
 )
 
 func main() {

--- a/_includes/code/1.x/backup.status.create.html
+++ b/_includes/code/1.x/backup.status.create.html
@@ -36,8 +36,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/backup"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/backup"
 )
 
 func main() {

--- a/_includes/code/1.x/backup.status.restore.html
+++ b/_includes/code/1.x/backup.status.restore.html
@@ -36,8 +36,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/backup"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/backup"
 )
 
 func main() {

--- a/_includes/code/1.x/batch.delete.objects.html
+++ b/_includes/code/1.x/batch.delete.objects.html
@@ -67,8 +67,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
 )
 
 func main() {

--- a/_includes/code/1.x/batch.objects.html
+++ b/_includes/code/1.x/batch.objects.html
@@ -137,7 +137,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/batch.references.html
+++ b/_includes/code/1.x/batch.references.html
@@ -134,7 +134,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/classification.contextual.post.html
+++ b/_includes/code/1.x/classification.contextual.post.html
@@ -73,9 +73,9 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/classifications"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/classifications"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
 )
 
 func main() {

--- a/_includes/code/1.x/classification.get.html
+++ b/_includes/code/1.x/classification.get.html
@@ -36,7 +36,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/classification.knn.post.articles.html
+++ b/_includes/code/1.x/classification.knn.post.articles.html
@@ -62,8 +62,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/classifications"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/classifications"
   "github.com/semi-technologies/weaviate/usecases/classification"
 )
 

--- a/_includes/code/1.x/classification.knn.post.html
+++ b/_includes/code/1.x/classification.knn.post.html
@@ -71,9 +71,9 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/classifications"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/classifications"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
   "github.com/semi-technologies/weaviate/usecases/classification"
 )
 

--- a/_includes/code/1.x/classification.post.html
+++ b/_includes/code/1.x/classification.post.html
@@ -47,8 +47,8 @@ package main
 import (
   "context"
   "fmt"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/classifications"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/classifications"
   "github.com/semi-technologies/weaviate/usecases/classification"
 )
 

--- a/_includes/code/1.x/classification.zeroshot.post.html
+++ b/_includes/code/1.x/classification.zeroshot.post.html
@@ -70,9 +70,9 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/classifications"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/classifications"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
 )
 
 func main() {

--- a/_includes/code/1.x/contextionary.extensions.html
+++ b/_includes/code/1.x/contextionary.extensions.html
@@ -34,7 +34,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/contextionary.get.html
+++ b/_includes/code/1.x/contextionary.get.html
@@ -34,7 +34,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/getting-started.clients.1.html
+++ b/_includes/code/1.x/getting-started.clients.1.html
@@ -41,8 +41,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/getting-started.clients.2.html
+++ b/_includes/code/1.x/getting-started.clients.2.html
@@ -41,8 +41,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/getting-started.import.create.html
+++ b/_includes/code/1.x/getting-started.import.create.html
@@ -121,7 +121,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 
 )

--- a/_includes/code/1.x/getting-started.import.get.html
+++ b/_includes/code/1.x/getting-started.import.get.html
@@ -42,7 +42,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func GetSchema() {

--- a/_includes/code/1.x/getting-started.import.publications.html
+++ b/_includes/code/1.x/getting-started.import.publications.html
@@ -117,7 +117,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 	"github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/getting-started.schema.connect.html
+++ b/_includes/code/1.x/getting-started.schema.connect.html
@@ -53,7 +53,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func GetSchema() {

--- a/_includes/code/1.x/getting-started.schema.create.1.html
+++ b/_includes/code/1.x/getting-started.schema.create.1.html
@@ -151,7 +151,7 @@ package main
 import (
 	"context"
     "fmt"
-    "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+    "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
     "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/getting-started.schema.create.2.html
+++ b/_includes/code/1.x/getting-started.schema.create.2.html
@@ -96,7 +96,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 
 )

--- a/_includes/code/1.x/getting-started.schema.crossreference.1.html
+++ b/_includes/code/1.x/getting-started.schema.crossreference.1.html
@@ -70,7 +70,7 @@ import (
   "context"
 	"fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/getting-started.schema.crossreference.2.html
+++ b/_includes/code/1.x/getting-started.schema.crossreference.2.html
@@ -70,7 +70,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/graphql.aggregate.groupby.html
+++ b/_includes/code/1.x/graphql.aggregate.groupby.html
@@ -66,8 +66,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.aggregate.nearObject.html
+++ b/_includes/code/1.x/graphql.aggregate.nearObject.html
@@ -82,8 +82,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.aggregate.nearText.html
+++ b/_includes/code/1.x/graphql.aggregate.nearText.html
@@ -80,8 +80,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.aggregate.nearVector.html
+++ b/_includes/code/1.x/graphql.aggregate.nearVector.html
@@ -80,8 +80,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.aggregate.simple.html
+++ b/_includes/code/1.x/graphql.aggregate.simple.html
@@ -67,8 +67,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.explore.simple.html
+++ b/_includes/code/1.x/graphql.explore.simple.html
@@ -88,8 +88,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.explore.vector.html
+++ b/_includes/code/1.x/graphql.explore.vector.html
@@ -69,8 +69,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.group.html
+++ b/_includes/code/1.x/graphql.filters.group.html
@@ -73,8 +73,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.limit.html
+++ b/_includes/code/1.x/graphql.filters.limit.html
@@ -50,8 +50,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.nearObject.html
+++ b/_includes/code/1.x/graphql.filters.nearObject.html
@@ -67,8 +67,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.nearText.2obj.html
+++ b/_includes/code/1.x/graphql.filters.nearText.2obj.html
@@ -91,8 +91,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.nearText.html
+++ b/_includes/code/1.x/graphql.filters.nearText.html
@@ -94,8 +94,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.nearText.huggingface.html
+++ b/_includes/code/1.x/graphql.filters.nearText.huggingface.html
@@ -100,8 +100,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.nearText.openai.html
+++ b/_includes/code/1.x/graphql.filters.nearText.openai.html
@@ -100,8 +100,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.nearVector.html
+++ b/_includes/code/1.x/graphql.filters.nearVector.html
@@ -68,8 +68,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.offset.html
+++ b/_includes/code/1.x/graphql.filters.offset.html
@@ -61,8 +61,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.beacon.count.html
+++ b/_includes/code/1.x/graphql.filters.where.beacon.count.html
@@ -128,9 +128,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.beacon.html
+++ b/_includes/code/1.x/graphql.filters.where.beacon.html
@@ -75,9 +75,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.geocoordinates.html
+++ b/_includes/code/1.x/graphql.filters.where.geocoordinates.html
@@ -104,9 +104,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.id.html
+++ b/_includes/code/1.x/graphql.filters.where.id.html
@@ -70,9 +70,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.like.html
+++ b/_includes/code/1.x/graphql.filters.where.like.html
@@ -70,9 +70,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.operands.html
+++ b/_includes/code/1.x/graphql.filters.where.operands.html
@@ -93,9 +93,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.simple.html
+++ b/_includes/code/1.x/graphql.filters.where.simple.html
@@ -70,9 +70,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.filters.where.timestamps.html
+++ b/_includes/code/1.x/graphql.filters.where.timestamps.html
@@ -71,9 +71,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.get.beacon.html
+++ b/_includes/code/1.x/graphql.get.beacon.html
@@ -59,8 +59,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.get.simple.html
+++ b/_includes/code/1.x/graphql.get.simple.html
@@ -51,8 +51,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.get.sorting.html
+++ b/_includes/code/1.x/graphql.get.sorting.html
@@ -86,8 +86,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.underscoreproperties.certainty.html
+++ b/_includes/code/1.x/graphql.underscoreproperties.certainty.html
@@ -70,8 +70,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.underscoreproperties.classification.html
+++ b/_includes/code/1.x/graphql.underscoreproperties.classification.html
@@ -79,8 +79,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.underscoreproperties.distance.html
+++ b/_includes/code/1.x/graphql.underscoreproperties.distance.html
@@ -70,8 +70,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.underscoreproperties.featureprojection.html
+++ b/_includes/code/1.x/graphql.underscoreproperties.featureprojection.html
@@ -97,8 +97,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.underscoreproperties.interpretation.html
+++ b/_includes/code/1.x/graphql.underscoreproperties.interpretation.html
@@ -76,8 +76,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.underscoreproperties.nearestneighbors.html
+++ b/_includes/code/1.x/graphql.underscoreproperties.nearestneighbors.html
@@ -118,8 +118,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/graphql.underscoreproperties.semanticpath.html
+++ b/_includes/code/1.x/graphql.underscoreproperties.semanticpath.html
@@ -109,8 +109,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.add.data.things.add.reference.html
+++ b/_includes/code/1.x/howto.add.data.things.add.reference.html
@@ -72,7 +72,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.add.data.things.html
+++ b/_includes/code/1.x/howto.add.data.things.html
@@ -46,7 +46,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.add.data.things.reference.html
+++ b/_includes/code/1.x/howto.add.data.things.reference.html
@@ -55,7 +55,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.customvectors.adddata.html
+++ b/_includes/code/1.x/howto.customvectors.adddata.html
@@ -46,7 +46,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.customvectors.nearvector.html
+++ b/_includes/code/1.x/howto.customvectors.nearvector.html
@@ -59,8 +59,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.customvectors.schemacreate.html
+++ b/_includes/code/1.x/howto.customvectors.schemacreate.html
@@ -52,7 +52,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/howto.query.data.html
+++ b/_includes/code/1.x/howto.query.data.html
@@ -76,9 +76,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/filters"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/filters"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.schema.create.html
+++ b/_includes/code/1.x/howto.schema.create.html
@@ -75,7 +75,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/howto.schema.property.add.html
+++ b/_includes/code/1.x/howto.schema.property.add.html
@@ -51,7 +51,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/howto.semanticsearch.filter.html
+++ b/_includes/code/1.x/howto.semanticsearch.filter.html
@@ -95,8 +95,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/howto.semanticsearch.function.html
+++ b/_includes/code/1.x/howto.semanticsearch.function.html
@@ -86,8 +86,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/img2vec-neural.create.html
+++ b/_includes/code/1.x/img2vec-neural.create.html
@@ -48,7 +48,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/img2vec-neural.nearimage.encode.html
+++ b/_includes/code/1.x/img2vec-neural.nearimage.encode.html
@@ -83,8 +83,8 @@ import (
   "fmt"
   "os"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/img2vec-neural.nearimage.html
+++ b/_includes/code/1.x/img2vec-neural.nearimage.html
@@ -60,8 +60,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/meta.html
+++ b/_includes/code/1.x/meta.html
@@ -33,7 +33,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/ner-transformers-module.html
+++ b/_includes/code/1.x/ner-transformers-module.html
@@ -71,8 +71,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/nodes.html
+++ b/_includes/code/1.x/nodes.html
@@ -29,7 +29,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/qna-transformers.ask.html
+++ b/_includes/code/1.x/qna-transformers.ask.html
@@ -84,8 +84,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/schema.dump.html
+++ b/_includes/code/1.x/schema.dump.html
@@ -34,7 +34,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/schema.get.class.html
+++ b/_includes/code/1.x/schema.get.class.html
@@ -38,7 +38,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/schema.shards.get.html
+++ b/_includes/code/1.x/schema.shards.get.html
@@ -27,7 +27,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/schema.shards.put.html
+++ b/_includes/code/1.x/schema.shards.put.html
@@ -48,7 +48,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/schema.things.create.elaborate.html
+++ b/_includes/code/1.x/schema.things.create.elaborate.html
@@ -159,7 +159,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/schema.things.create.html
+++ b/_includes/code/1.x/schema.things.create.html
@@ -78,7 +78,7 @@ package main
 import (
     "context"
 
-    "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+    "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
     "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/schema.things.delete.html
+++ b/_includes/code/1.x/schema.things.delete.html
@@ -36,7 +36,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/schema.things.properties.add.html
+++ b/_includes/code/1.x/schema.things.properties.add.html
@@ -46,7 +46,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/semantic-kind.create.geocoordinates.html
+++ b/_includes/code/1.x/semantic-kind.create.geocoordinates.html
@@ -52,7 +52,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.create.html
+++ b/_includes/code/1.x/semantic-kind.create.html
@@ -51,7 +51,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.create.vector.html
+++ b/_includes/code/1.x/semantic-kind.create.vector.html
@@ -52,7 +52,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.get.html
+++ b/_includes/code/1.x/semantic-kind.get.html
@@ -36,7 +36,7 @@ import (
     "context"
     "fmt"
 
-    "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+    "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.object.delete.html
+++ b/_includes/code/1.x/semantic-kind.object.delete.html
@@ -33,7 +33,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.object.get.html
+++ b/_includes/code/1.x/semantic-kind.object.get.html
@@ -36,7 +36,7 @@ import (
     "context"
     "fmt"
 
-    "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+    "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.object.head.html
+++ b/_includes/code/1.x/semantic-kind.object.head.html
@@ -35,7 +35,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.object.reference.add.html
+++ b/_includes/code/1.x/semantic-kind.object.reference.add.html
@@ -48,7 +48,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.object.reference.delete.html
+++ b/_includes/code/1.x/semantic-kind.object.reference.delete.html
@@ -47,7 +47,7 @@ package main
 import (
     "context"
 
-    "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+    "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.object.reference.update.html
+++ b/_includes/code/1.x/semantic-kind.object.reference.update.html
@@ -52,7 +52,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
   "github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/semantic-kind.object.update.html
+++ b/_includes/code/1.x/semantic-kind.object.update.html
@@ -63,7 +63,7 @@ package main
 import (
     "context"
 
-    "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+    "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/semantic-kind.validate.html
+++ b/_includes/code/1.x/semantic-kind.validate.html
@@ -43,7 +43,7 @@ package main
 import (
   "context"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/spellcheck-module.html
+++ b/_includes/code/1.x/spellcheck-module.html
@@ -76,8 +76,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/sum-transformers-module.html
+++ b/_includes/code/1.x/sum-transformers-module.html
@@ -65,8 +65,8 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate/graphql"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate/graphql"
 )
 
 func main() {

--- a/_includes/code/1.x/text2vec-openai.example.html
+++ b/_includes/code/1.x/text2vec-openai.example.html
@@ -41,7 +41,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 	"github.com/semi-technologies/weaviate/entities/models"
 )
 

--- a/_includes/code/1.x/wellknown.live.html
+++ b/_includes/code/1.x/wellknown.live.html
@@ -33,7 +33,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/wellknown.openid-configuration.html
+++ b/_includes/code/1.x/wellknown.openid-configuration.html
@@ -34,7 +34,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/_includes/code/1.x/wellknown.ready.html
+++ b/_includes/code/1.x/wellknown.ready.html
@@ -33,7 +33,7 @@ import (
   "context"
   "fmt"
 
-  "github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+  "github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func main() {

--- a/developers/weaviate/current/client-libraries/go.md
+++ b/developers/weaviate/current/client-libraries/go.md
@@ -19,10 +19,10 @@ redirect_from:
 To get the latest stable version of the Go client library, run the following:
 
 ```bash
-go get github.com/semi-technologies/weaviate-go-client/v4
+go get github.com/semi-technologies/weaviate-go-client/v5
 ```
 
-This API client is compatible with Go 1.16+.
+This API client is compatible with Go 1.19+.
 
 You can use the client in your Go scripts as follows:
 
@@ -32,7 +32,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/semi-technologies/weaviate-go-client/v4/weaviate"
+	"github.com/semi-technologies/weaviate-go-client/v5/weaviate"
 )
 
 func GetSchema() {
@@ -81,7 +81,7 @@ The code snippet above shows a simple query similar to `RESTful GET /v1/schema`.
 
 # Migration Guides
 
-## From `v2` to `v4`
+## From `v2` to `v5`
 
 ### Unnecessary `.Objects()` removed from `GraphQL.Get()`
 
@@ -99,7 +99,7 @@ client.GraphQL().Get().WithClassName
 
 ### GraphQL `Get().WithNearVector()` uses a builder pattern
 
-In `v2` specifying a `nearVector` argument to `client.GraphQL().Get()` required passing a string. As a result the user had to know the structure of the GraphQL API. `v4` fixes this by using a builder pattern like so:
+In `v2` specifying a `nearVector` argument to `client.GraphQL().Get()` required passing a string. As a result the user had to know the structure of the GraphQL API. Since `v4`, a `WithNearVector` method was introduced to set the search vector using the builder pattern.
 
 Before:
 
@@ -121,7 +121,7 @@ client.GraphQL().Get().
 
 ### All `where` filters use the same builder
 
-In `v2` filters were sometimes specified as strings, sometimes in a structured way. `v4` unifies this and makes sure that you can always use the same builder pattern.
+In `v2` filters were sometimes specified as strings, sometimes in a structured way. Since `v4`, this was unified to make sure that you can always use the same builder pattern.
 
 #### GraphQL Get
 
@@ -273,7 +273,7 @@ client.GraphQL.Get().WithClassName("MyClass").WithGroup(group)
 
 ### Graphql `Data().Validator()` property renamed
 
-In `v2` the naming of the method to specify the Schema was inconsistent with other places in the client. This has been fixed in `v4`. Rename according to the following:
+In `v2` the naming of the method to specify the Schema was inconsistent with other places in the client. This has been fixed since `v4`. Rename according to the following:
 
 Before:
 ```go
@@ -287,6 +287,9 @@ client.Data().Validator().WithProperties(properties)
 
 
 # Change logs
+
+## v5.0.0
+- Minimum Go version set to 1.19
 
 ## v4.3.0
 - Added support for [backup](../configuration/backups.html) API

--- a/developers/weaviate/current/getting-started/schema.md
+++ b/developers/weaviate/current/getting-started/schema.md
@@ -54,7 +54,7 @@ $ npm install weaviate-client
 
 * For `Go` add `weaviate-go-client` to your project with `go get`:
   ```bash
-go get github.com/semi-technologies/weaviate-go-client/v4
+go get github.com/semi-technologies/weaviate-go-client/v5
   ```
 
 ## Connect to Weaviate


### PR DESCRIPTION
Go client version was bumped to v5 during the Weaviate v1.16 release. This PR updates the docs accordingly.