### PR TITLE
"Config" yaml ref update; minor clarifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ _site/
 .jekyll-metadata
 .ruby-version
 img/og/og-documentation
+
+# docusaurus-related files left over from another branch
+.docusaurus/
+node_modules/
+yarn.lock

--- a/developers/weaviate/current/configuration/authentication.md
+++ b/developers/weaviate/current/configuration/authentication.md
@@ -18,20 +18,20 @@ redirect_from:
 
 We built Weaviate to be as easy to use as possible while catering to different cases such as for trying it out locally, or in production in an enterprise environment.
 
-Weaviate's authentication capabilities reflect this by allowing for both anonymous uses as well as authenticated uses through OpenID Connect (OIDC). Thus, different authentication schemes can be selected and even combined, from which different [authorization](./authorization.html) options can be specified for different sets of users. This allows scenarios such as _"Anonymous users can read some resources, but not all. Authenticated users can read all resources. Only a special subset of admin users can write or delete resources."_
+Weaviate's authentication capabilities reflect this by allowing for both anonymous users as well as authenticated users through OpenID Connect (OIDC). Thus, different authentication schemes can be selected and even combined, from which different [authorization](./authorization.html) options can be specified for different sets of users. 
 
 ## Anonymous Access
 By default, Weaviate is configured to accept requests without any
 authentication headers or parameters. Users sending such requests will be
 authenticated as `user: anonymous`.
 
-You can use the authorization module to specify which
+You can use the authorization plugin to specify which
 permissions to apply to anonymous users. When anonymous access is disabled altogether,
 any request without an allowed authentication scheme will return `401
 Unauthorized`.
 
 ### Configuration
-Anonymous access can be enabled or disabled in the Docker Compose yaml using the environment variable shown below:
+Anonymous access can be enabled or disabled in the configuration yaml using the environment variable shown below:
 
 ```yaml
 services:
@@ -69,7 +69,7 @@ correct, all contents of the token are trusted, which authenticates the user bas
 
 ### Configuration
 
-To use OpenID Connect (OIDC), the **respective environment variables** must be correctly configured in the Docker Compose yaml for Weaviate. Additionally, the **OIDC token issuer** must be configured as appropriate. Configuring the OIDC token issuer is outside the scope of this document.
+To use OpenID Connect (OIDC), the **respective environment variables** must be correctly configured in the configuration yaml for Weaviate. Additionally, the **OIDC token issuer** must be configured as appropriate. Configuring the OIDC token issuer is outside the scope of this document.
 
 > As of November 2022, we are aware of some differences in Microsoft Azure's OIDC implementation compared to others. If you are using Azure and experiencing difficulties, [this external blog post](https://xsreality.medium.com/making-azure-ad-oidc-compliant-5734b70c43ff){:target="_blank"} may be useful.
 
@@ -106,7 +106,7 @@ services:
       AUTHENTICATION_OIDC_CLIENT_ID: 'my-weaviate-client'
 
       # username_claim (required) tells weaviate which claim to use for extracting
-      # the username. The username will be passed to the authorization module.      
+      # the username. The username will be passed to the authorization plugin.      
       AUTHENTICATION_OIDC_USERNAME_CLAIM: 'email'
 
       # skip_client_id_check (optional, defaults to false) skips the client_id

--- a/developers/weaviate/current/configuration/authorization.md
+++ b/developers/weaviate/current/configuration/authorization.md
@@ -14,13 +14,16 @@ redirect_from:
     - /documentation/weaviate/current/configuration/authorization.html
 ---
 
+# Overview
+
+The authorization plugin allows Weaviate to provide differentiated access to users based on their [authentication](./authentication.html) status. Along with allowing or disallowing anonymous access, Weaviate can differentiate between a user who is in the admin list, or on the read-only list.
+
 # Admin List
 
-Admin List relies on the configured `Authentication Schema` to correctly identify
+The admin list relies on the configured `Authentication Schema` to correctly identify
 the user. On each request, a check against a pre-configured admin list is done.
 If the user is contained in this list, they get all permissions. If they aren't,
-they get none. It's not possible to assign only some rights to a specific user
-with the Admin List plugin.
+they get none. It is not currently possible to assign only some rights to a specific user.
 
 # Read-Only list
 
@@ -29,11 +32,11 @@ Those users have permissions on all `get` and `list` operations, but no other
 permissions.
 
 If a subject is present on both the admin and read-only list, Weaviate will
-error on startup due to the invalid configuration.
+throw an error on startup due to the invalid configuration.
 
 # Usage
 
-Configure the admin plugin in the Docker Compose configuration yaml like so:
+Configure the admin plugin in the configuration yaml like so:
 
 ```yaml
 services:

--- a/developers/weaviate/current/configuration/index.md
+++ b/developers/weaviate/current/configuration/index.md
@@ -18,6 +18,10 @@ When setting up a Weaviate instance, by default, it will be:
 - With the [vector index type](./vector-index-type.html) `hnsw`. This will be configurable soon.
 - Without any form of authentication and authorization. Check the pages about [authentication](./authentication.html) and [authorization](./authorization.html) how to enable this.
 
-How to configure your docker-compose file, check the [Installation page](../getting-started/installation.html#docker-compose).
+You may have seen in the [Installation section](../installation/index.html) for Docker Compose or Kubernetes that Weaviate's settings can be changed by modifying the relevant configuration file.
+
+This section is a collection of guides to delve further into the details on how to configure various settings and customize Weaviate to suit your needs. 
+
+You do not need to read this section linearly. But we do recommend that you browse through this section so that you are aware of the available main customization options, including features that will help you to take it into production.
 
 For configuration of your data schema, check the [Tutorial](../tutorials/how-to-create-a-schema.html) or the [data schema reference page](../schema/schema-configuration.html).

--- a/developers/weaviate/current/installation/index.md
+++ b/developers/weaviate/current/installation/index.md
@@ -20,6 +20,8 @@ redirect_from:
 
 You have three options to run Weaviate, all come with their own installation guides.
 
+> 💡 Both Docker Compose and Kubernetes setups use a yaml file for customizing Weaviate instances, typically called `docker-compose.yml` or `values.yml` respectively. These files will be referred to throughout the documentation as 'configuration yaml files'. 
+
 * [Weaviate Cluster Service](./weaviate-cloud-service.html) – advised for users who want to use a managed Weaviate service.
 * [Docker Compose](./docker-compose.html) – advised for those who want to develop on Weaviate.
 * [Kubernetes](./kubernetes.html) – advised for production setups.


### PR DESCRIPTION
### What's being changed:

- Changed some of the refs to "docker-compose.yml" to "configuration yaml files" or similar
  - Intended to cover "values.yaml" for Kubernetes as well as "docker-compose.yaml"
- Added Docusaurus files to gitignore
- Changed references to authentication "modules" to "plugins" for consistency
- Clarified what is possible with differentiated authentication + authorization 

### Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature or enhancements (non-breaking change which adds functionality)
- [X] Documentation updates (non-breaking change which updates documents)