### PR TITLE
add spotify button for podcasts and update docker file to be able to …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update &&\
     apt-get install python3-pip -y &&\
     pip3 install requests pyyaml
 ADD . ./
-RUN python3 tools/create-roadmap.py
+RUN python3 _python/create-roadmap.py
 
 CMD bundle exec jekyll s --watch --livereload --incremental --host=0.0.0.0 --baseurl="" --config "_config.yml,_config_dev.yml" --open-url http://0.0.0.0:4000/
 

--- a/podcast.md
+++ b/podcast.md
@@ -20,8 +20,12 @@ regenerate: true
                 </p>
                 <!-- Buttons -->
                 <div class="text-center text-md-start">
-                    <a href="https://www.youtube.com/playlist?list=PLTL2JUbrY6tW-KOQfOek8dtUmPgGQj3F0" class="btn btn-primary-soft lift" target="_blank">
-                        Subscribe to the Youtube channel <i class="fe fe-youtube d-none d-md-inline ms-3"></i>
+                    <a href="https://www.youtube.com/playlist?list=PLTL2JUbrY6tW-KOQfOek8dtUmPgGQj3F0" class="btn btn-primary-soft lift m-2" target="_blank">
+                        Subscribe to the Youtube channel <i class="fe fe-youtube d-none d-md-inline ms-2 align-middle"></i>
+                    </a>
+                       <a href="
+                       https://open.spotify.com/show/4TlG6dnrWYdgN2YHpoSnM7" class="btn btn-secondary-soft lift m-2" target="_blank">
+                        Open in Spotify <i class="fab fa-spotify d-none d-md-inline ms-2 align-middle"></i>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION

### What's being changed:
- Added a button with URL to Spotify for /podcasts.html
- Small docker file change for create-roadmap.py. You can find it in the ` _python` folder,  not the `tools` folder. With this change, you're able to build a docker image.

### Type of change:
- [x] Feature or enhancements (non-breaking change which adds functionality)

### How Has This Been Tested?
- dev test on the local environment 
