### PR TITLE
docs: copyedit spellcheck + related fixes

### DIFF
--- a/_includes/code/1.x/spellcheck-module.html
+++ b/_includes/code/1.x/spellcheck-module.html
@@ -2,13 +2,13 @@
 {% capture graphql %}
 {
   Get {
-    Article(nearText:{
+    Article(nearText: {
       concepts: ["houssing prices"]
     }) {
       title
-      _additional{
-        spellCheck{
-          changes{
+      _additional {
+        spellCheck {
+          changes {
             corrected
             original
           }
@@ -176,16 +176,16 @@ public class App {
 
 <!-- SET CURL TAB CONTENT -->
 {% capture curl %}
-$ echo '{ 
+$ echo '{
   "query": "{
     Get {
-      Article(nearText:{
+      Article(nearText: {
         concepts: ["houssing prices"]
       }) {
         title
-        _additional{
-          spellCheck{
-            changes{
+        _additional {
+          spellCheck {
+            changes {
               corrected
               original
             }

--- a/developers/weaviate/current/more-resources/migration-guide.md
+++ b/developers/weaviate/current/more-resources/migration-guide.md
@@ -158,26 +158,26 @@ upgrading.
 * No breaking changes
 * New features
   * ### Array Datatypes (#1611)
-  Starting with this releases, primitive object properties are no longer limited to individual properties, but can also include lists of primitives. Array types can be stored, filtered and aggregated in the same way as other primitives.
+    Starting with this release, primitive object properties are no longer limited to individual properties, but can also include lists of primitives. Array types can be stored, filtered and aggregated in the same way as other primitives.
 
     Auto-schema will automatically recognize lists of `string`/`text` and `number`/`int`. You can also explicitly specify lists in the schema by using the following data types `string[]`, `text[]`, `int[]`, `number[]`. A type that is assigned to be an array, must always stay an array, even if it only contains a single element. 
 
-  * ### New Module: `text-spellcheck` - Check and auto-correct misspelled search terms (#1606)
+  * ### New Module: `text-spellcheck` - Check and autocorrect misspelled search terms (#1606)
     Use the new spellchecker module to verify user-provided search queries (in existing `nearText` or `ask` functions) are spelled correctly and even suggest alternative, correct spellings. Spell-checking happens at query time. 
 
     There are two ways to use this module:
-    1. It provides a new additional prop which can be used to check (but not alter) the provided queries:
+    1. It provides a new additional property which can be used to check (but not alter) the provided queries:
     The following query:
     ```graphql
     {
       Get {
-        Post(nearText:{
+        Post(nearText: {
           concepts: "missspelled text"
         }) {
           content
-          _additional{
-            spellCheck{
-              changes{
+          _additional {
+            spellCheck {
+              changes {
                 corrected
                 original
               }
@@ -191,7 +191,7 @@ upgrading.
     }
     ```
     
-    will produce results, similar to the following:
+    will produce results similar to the following:
     
     ```
       "_additional": {
@@ -212,12 +212,12 @@ upgrading.
       "content": "..."
     },
     ```
-    2. It extends existing `text2vec-modules` with a `autoCorrect` flag, which can be used to correct the query if incorrect in the background.
+    2. It extends existing `text2vec-*` modules with an `autoCorrect` flag, which can be used to automatically correct the query if misspelled.
 
   * ### New Module `ner-transformers` - Extract entities from Weaviate using transformers (#1632)
-    Use transformer-based models to extract entities from your existing Weaviate objects on the fly. Entity Extraction happens at query time. Note that for maximum performance, transformer-based models should run with GPUs. CPUs can be used, but the throughput will be lower.
+    Use transformer-based models to extract entities from your existing Weaviate objects on the fly. Entity extraction happens at query time. Note that for maximum performance, transformer-based models should run with GPUs. CPUs can be used, but the throughput will be lower.
 
-    To make use of the modules capabilities, simply extend your query with the following new `_additional` property:
+    To make use of the module's capabilities, simply extend your query with the following new `_additional` property:
 
     ```graphql
     {

--- a/developers/weaviate/current/other-modules/spellcheck.md
+++ b/developers/weaviate/current/other-modules/spellcheck.md
@@ -3,7 +3,7 @@ layout: layout-documentation
 solution: weaviate
 sub-menu: Other Modules
 nav-parent: Modules
-title: spellcheck
+title: Spell Check
 description: Weaviate spellcheck module
 tags: ['spellcheck']
 menu-order: 1
@@ -15,20 +15,20 @@ redirect_from:
 ---
 
 # In short
-* The SpellCheck module is a Weaviate module for spell checking of raw text in GraphQL queries.
-* The module depends on a Python spellchecking service.
-* The module adds an `spellCheck {}` filter to the GraphQL `nearText {}` search arguments.
-* The module returns the spelling check result in the GraphQL `_additional { spellCheck {} }` field. 
+* The Spell Check module is a Weaviate module for spell checking of raw text in GraphQL queries.
+* The module depends on a Python spellchecking library.
+* The module adds a `spellCheck {}` filter to the GraphQL `nearText {}` search arguments.
+* The module returns the spelling check result in the GraphQL `_additional { spellCheck {} }` field.
 
 # Introduction
 
-The SpellCheck module is a Weaviate module for checking spelling in raw texts in GraphQL query inputs. Using [the Python spellchecker](https://pypi.org/project/pyspellchecker/) as service, the module analyzes text, gives a suggestion and can force an auto-correction. 
+The Spell Check module is a Weaviate module for checking spelling in raw texts in GraphQL query inputs. Using the [Python spellchecker](https://pypi.org/project/pyspellchecker/) library, the module analyzes text, gives a suggestion and can force an autocorrection.
 
 # How to enable (module configuration)
 
 ### Docker-compose
 
-The Q&A module can be added as a service to the Docker-compose file. You must have a text vectorizer like `text2vec-contextionary` or `text2vec-transformers` running. An example Docker-compose file for using the `spellcheck` module with the `text2vec-contextionary` is here:
+The Spell Check module can be added as a service to the Docker-compose file. You must have a text vectorizer like `text2vec-contextionary` or `text2vec-transformers` running. An example Docker-compose file for using the `text-spellcheck` module with the `text2vec-contextionary` is here:
 
 ```yaml
 ---
@@ -75,11 +75,16 @@ Variable explanations:
 
 # How to use (GraphQL)
 
-Use the new spellchecker module to verify user-provided search queries (in existing `nearText` (given that a `text2vec` module is used) or `ask` (if the `qna-transformers` module is enabled) functions) are spelled correctly and even suggest alternative, correct spellings. Spell-checking happens at query time.
+Use the spellchecker module to verify at query time that user-provided search queries are spelled correctly and even suggest alternative, correct spellings. Filters that accept query text include:
 
-There are two ways to use this module:
+* [`nearText`](../graphql-references/vector-search-parameters#neartext), if a `text2vec-*` module is used
+* `ask`, if the [`qna-transformers`](../reader-generator-modules/qna-transformers) module is enabled
 
-1. It provides a new GraphQL `_additional` property which can be used to check (but not alter) the provided queries, see query below.
+There are two ways to use this module: spell checking, and autocorrection.
+
+## Spell checking
+
+The module provides a new GraphQL `_additional` property which can be used to check (but not alter) the provided queries.
 
 ### Example query
 
@@ -89,8 +94,8 @@ There are two ways to use this module:
 
 The result is contained in a new GraphQL `_additional` property called `spellCheck`. It contains the following fields:
 * `changes`: a list with the following fields:
-    * `corrected` (`string`): the corrected spelling if a correction is found
-    * `original` (`string`): the original spelled word in the query
+  * `corrected` (`string`): the corrected spelling if a correction is found
+  * `original` (`string`): the original word in the query
 * `didYouMean`: the corrected full text in the query
 * `originalText`: the original full text in the query
 * `location`: the location of the misspelled string in the query
@@ -127,21 +132,23 @@ The result is contained in a new GraphQL `_additional` property called `spellChe
 }
 ```
 
-2. It extends existing `text2vec-modules` with a `autoCorrect` flag, which can be used to correct the query if incorrect in the background:
+## Autocorrect
+
+The module extends existing `text2vec-*` modules with an `autoCorrect` flag, which can be used to automatically correct the query if it was misspelled:
 
 ### Example query
 
 ```graphql
 {
   Get {
-    Article(nearText:{
+    Article(nearText: {
       concepts: ["houssing prices"],
       autocorrect: true
     }) {
       title
-      _additional{
-        spellCheck{
-          changes{
+      _additional {
+        spellCheck {
+          changes {
             corrected
             original
           }

--- a/developers/weaviate/current/other-modules/spellcheck.md
+++ b/developers/weaviate/current/other-modules/spellcheck.md
@@ -77,8 +77,8 @@ Variable explanations:
 
 Use the spellchecker module to verify at query time that user-provided search queries are spelled correctly and even suggest alternative, correct spellings. Filters that accept query text include:
 
-* [`nearText`](../graphql-references/vector-search-parameters#neartext), if a `text2vec-*` module is used
-* `ask`, if the [`qna-transformers`](../reader-generator-modules/qna-transformers) module is enabled
+* [`nearText`](../graphql-references/vector-search-parameters.html#neartext), if a `text2vec-*` module is used
+* `ask`, if the [`qna-transformers`](../reader-generator-modules/qna-transformers.html) module is enabled
 
 There are two ways to use this module: spell checking, and autocorrection.
 


### PR DESCRIPTION
* set the module title to "Spell Check", in alignment with the other modules, which use the full title, e.g. `Named Entity Recognition` instead of the module name in the Docker compose file (`ner-transformers`)
* add links to `nearText` and `ask`
  * and simplify language around double parentheses
* clarify that a Python *library* is used, and not a (presumably online) spell checking service
* fix the numbering of the two ways in which the module can be used
* format GraphQL query with spaces before `{`s
  * \+ drive-by fixes in the changelog

# Test
* https://weaviate.io/developers/weaviate/current/other-modules/spellcheck.html
* https://6386ca707c46ea643c57cf1d--tangerine-buttercream-20c32f.netlify.app/developers/weaviate/current/other-modules/spellcheck.html