### PR TITLE
Removed enterprise usage collector & refs

### DIFF
--- a/developers/weaviate/current/configuration/_enterprise-usage-collector.md
+++ b/developers/weaviate/current/configuration/_enterprise-usage-collector.md
@@ -12,6 +12,7 @@ redirect_from:
     - /developers/weaviate/v1.1.0/configuration/enterprise-usage-collector.html
 ---
 
+<!-- Hidden for now as no longer used; to be removed in the future. -->
 # Introduction
 
 When using Weaviate Enterprise, a proxy service is placed in between the user (or load balancer) and Weaviate. The service measures how Weaviate is used without sending through any sensitive information (e.g., function, durations, payload sizes). Below you can find an outline on how to add the proxy service to your setup.

--- a/developers/weaviate/current/getting-started/installation.md
+++ b/developers/weaviate/current/getting-started/installation.md
@@ -52,7 +52,7 @@ If you feel comfortable making a few changes to the code examples in the tutoria
 
 0. Get `docker-compose.yml` configuration file by calling:
     ```js
-    curl -o docker-compose.yml "https://configuration.semi.technology/v2/docker-compose/docker-compose.yml?enterprise_usage_collector=false&modules=standalone&runtime=docker-compose&weaviate_version={{ site.weaviate_version }}"
+    curl -o docker-compose.yml "https://configuration.semi.technology/v2/docker-compose/docker-compose.yml?modules=standalone&runtime=docker-compose&weaviate_version={{ site.weaviate_version }}"
     ```
 0. Sping up docker
     ```js

--- a/developers/weaviate/current/getting-started/schema.md
+++ b/developers/weaviate/current/getting-started/schema.md
@@ -21,7 +21,7 @@ At this point, you should have Weaviate running either:
 * in a sandbox on the [Weaviate Cloud Service](https://console.semi.technology)
     * if not, refer to the [Installation](./installation.html) lesson for instructions
 * or locally with Docker
-    0. Download [this `docker-compose.yml` file](https://configuration.semi.technology/v2/docker-compose/docker-compose.yml?enterprise_usage_collector=false&modules=standalone&runtime=docker-compose&weaviate_version={{ site.weaviate_version }}).
+    0. Download [this `docker-compose.yml` file](https://configuration.semi.technology/v2/docker-compose/docker-compose.yml?modules=standalone&runtime=docker-compose&weaviate_version={{ site.weaviate_version }}).
     0. Run `$ docker-compose up`
     0. Make sure that you always run `$ docker-compose down` after a shutdown(!)
 

--- a/developers/weaviate/current/tutorials/how-to-use-weaviate-without-modules.md
+++ b/developers/weaviate/current/tutorials/how-to-use-weaviate-without-modules.md
@@ -24,7 +24,7 @@ Make sure to have [`"docker-compose"`](https://docs.docker.com/compose/) install
 
 ### Download the Docker Compose configuration file. 
 ```bash
-$ curl -o docker-compose.yml "https://configuration.semi.technology/v2/docker-compose/docker-compose.yml?enterprise_usage_collector=false&modules=standalone&runtime=docker-compose&weaviate_version={{ site.weaviate_version }}"
+$ curl -o docker-compose.yml "https://configuration.semi.technology/v2/docker-compose/docker-compose.yml?modules=standalone&runtime=docker-compose&weaviate_version={{ site.weaviate_version }}"
 ```
 
 ### Start up Weaviate


### PR DESCRIPTION
### Why:

The Enterprise Usage Collector is deprecated.

### What's being changed:

Removes references to the Enterprise Usage Collector and hides the document. (To be removed later on.)

### Type of change:

- [x] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

Local build + tried changed CURL commands locally.
