### PR TITLE
copyedit: v1.2 transformer models blog post

### DIFF
--- a/_posts/blog/2021-03-30-Weaviate-1-2-transformer-models.md
+++ b/_posts/blog/2021-03-30-Weaviate-1-2-transformer-models.md
@@ -23,22 +23,22 @@ In the v1.0 release of Weaviate ([docs](/developers/weaviate/current/){:target="
 </div>
 
 ## What are transformers?
-A [transformer](https://en.wikipedia.org/wiki/Transformer_(machine_learning_model)){:target="_blank"} (e.g., [BERT](https://en.wikipedia.org/wiki/BERT_(language_model)){:target="_blank"}) is a deep learning model that is used for NLP-tasks. Within Weaviate the transformer module can be used to vectorize and query your data.
+A [transformer](https://en.wikipedia.org/wiki/Transformer_(machine_learning_model)){:target="_blank"} (e.g., [BERT](https://en.wikipedia.org/wiki/BERT_(language_model)){:target="_blank"}) is a deep learning model that is used for NLP tasks. Within Weaviate the transformer module can be used to vectorize and query your data.
 
 ## Getting started with out-of-the-box transformers in Weaviate
-By selecting the text-module in the [Weaviate configuration tool](/developers/weaviate/current/installation/docker-compose.html#configurator){:target="_blank"}, you can run Weaviate with transformers in one command. You can learn more about the Weaviate transformer module [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.html){:target="_blank"}.
+By selecting the text-module in the [Weaviate configuration tool](/developers/weaviate/current/installation/docker-compose#configurator){:target="_blank"}, you can run Weaviate with transformers in one command. You can learn more about the Weaviate transformer module [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers){:target="_blank"}.
 
 ![Weaviate configurator — selecting the Transformers module](/img/blog/weaviate-1.2/configurator-demo.gif)
 *Weaviate configurator — selecting the Transformers module*
 
 ## Custom transformer models
-You can also use custom transformer models that are compatible with Huggingface’s `AutoModel` and `AutoTokenzier`. Learn more about using custom models in Weaviate [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.html){:target="_blank"}.
+You can also use custom transformer models that are compatible with Huggingface’s `AutoModel` and `AutoTokenzier`. Learn more about using custom models in Weaviate [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers){:target="_blank"}.
 
 ## Q&A style questions on your own dataset answered in milliseconds
-Weaviate now allows you to get to sub-50ms results by using transformers on your own data, you can learn more about Weaviate’s speed in combination with transformers in [this article](https://towardsdatascience.com/a-sub-50ms-neural-search-with-distilbert-and-weaviate-4857ae390154){:target="_blank"}.
+Weaviate now allows you to get to sub-50ms results by using transformers on your own data. You can learn more about Weaviate’s speed in combination with transformers in [this article](https://towardsdatascience.com/a-sub-50ms-neural-search-with-distilbert-and-weaviate-4857ae390154){:target="_blank"}.
 
 ## What next
-Check out the [Getting Started with Weaviate](/developers/weaviate/current/getting-started/index.html){:target="_blank"} and begin building amazing apps with Weaviate.
+Check out the [Getting Started with Weaviate](/developers/weaviate/current/getting-started/index){:target="_blank"} and begin building amazing apps with Weaviate.
 
 You can reach out to us on [Slack](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw){:target="_blank"} or [Twitter](https://twitter.com/weaviate_io){:target="_blank"}.
 

--- a/_posts/blog/2021-03-30-Weaviate-1-2-transformer-models.md
+++ b/_posts/blog/2021-03-30-Weaviate-1-2-transformer-models.md
@@ -26,19 +26,19 @@ In the v1.0 release of Weaviate ([docs](/developers/weaviate/current/){:target="
 A [transformer](https://en.wikipedia.org/wiki/Transformer_(machine_learning_model)){:target="_blank"} (e.g., [BERT](https://en.wikipedia.org/wiki/BERT_(language_model)){:target="_blank"}) is a deep learning model that is used for NLP tasks. Within Weaviate the transformer module can be used to vectorize and query your data.
 
 ## Getting started with out-of-the-box transformers in Weaviate
-By selecting the text-module in the [Weaviate configuration tool](/developers/weaviate/current/installation/docker-compose#configurator){:target="_blank"}, you can run Weaviate with transformers in one command. You can learn more about the Weaviate transformer module [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers){:target="_blank"}.
+By selecting the text-module in the [Weaviate configuration tool](/developers/weaviate/current/installation/docker-compose.html#configurator){:target="_blank"}, you can run Weaviate with transformers in one command. You can learn more about the Weaviate transformer module [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.html){:target="_blank"}.
 
 ![Weaviate configurator — selecting the Transformers module](/img/blog/weaviate-1.2/configurator-demo.gif)
 *Weaviate configurator — selecting the Transformers module*
 
 ## Custom transformer models
-You can also use custom transformer models that are compatible with Huggingface’s `AutoModel` and `AutoTokenzier`. Learn more about using custom models in Weaviate [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers){:target="_blank"}.
+You can also use custom transformer models that are compatible with Huggingface’s `AutoModel` and `AutoTokenzier`. Learn more about using custom models in Weaviate [here](/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.html){:target="_blank"}.
 
 ## Q&A style questions on your own dataset answered in milliseconds
 Weaviate now allows you to get to sub-50ms results by using transformers on your own data. You can learn more about Weaviate’s speed in combination with transformers in [this article](https://towardsdatascience.com/a-sub-50ms-neural-search-with-distilbert-and-weaviate-4857ae390154){:target="_blank"}.
 
 ## What next
-Check out the [Getting Started with Weaviate](/developers/weaviate/current/getting-started/index){:target="_blank"} and begin building amazing apps with Weaviate.
+Check out the [Getting Started with Weaviate](/developers/weaviate/current/getting-started){:target="_blank"} and begin building amazing apps with Weaviate.
 
 You can reach out to us on [Slack](https://join.slack.com/t/weaviate/shared_invite/zt-goaoifjr-o8FuVz9b1HLzhlUfyfddhw){:target="_blank"} or [Twitter](https://twitter.com/weaviate_io){:target="_blank"}.
 


### PR DESCRIPTION
Current: https://weaviate.io/blog/2021/03/Weaviate-1-2-transformer-models.html
Proposed: https://6393142c498b092469aecdbb--tangerine-buttercream-20c32f.netlify.app/blog/2021/03/weaviate-1-2-transformer-models

* copyedit
* strip `.html` from links
