### PR TITLE
Custom vectors with vectorizer present

### DIFF
--- a/developers/weaviate/current/restful-api-references/objects.md
+++ b/developers/weaviate/current/restful-api-references/objects.md
@@ -145,7 +145,11 @@ If you want to fill the value of a `geoCoordinates` property, you need to specif
 
 When you don't want to use a vectorizer to calculate a vector for your data object, and want to enter the vector yourself, you can this this as follows. 
 
-1. First, make sure that the `"vectorizer"` is set to `"none"` in the right class in the [data schema](../schema/schema-configuration.html#vectorizer) (`"vectorizer": "none"`). This is important so Weaviate knows not to do rely on any of it's modules to do model inference. *Note: If you are running without any modules and have therefore already configured the default vectorizer to be `"none"` (`DEFAULT_VECTORIZER_MODULE="none"`), you can omit this step.*
+1. First, make sure that the `"vectorizer"` in the right class in the [data schema](../schema/schema-configuration.html#vectorizer) is either set to
+- `"none"` (`"vectorizer": "none"`), if you are running without any modules and have therefore already configured the default vectorizer to be `"none"` (`DEFAULT_VECTORIZER_MODULE="none"`), you can omit this step.
+- the same vectorizer with identical settings that you use to generate the vector that is entered.
+*Note: There is NO validation of this vector besides checking the vector length.* 
+
 2. Then, attach the vector in a special `"vector"` field. An example of this looks like: 
 
 {% include code/1.x/semantic-kind.create.vector.html %}

--- a/developers/weaviate/current/restful-api-references/objects.md
+++ b/developers/weaviate/current/restful-api-references/objects.md
@@ -141,16 +141,29 @@ If you want to fill the value of a `geoCoordinates` property, you need to specif
 
 {% include code/1.x/semantic-kind.create.geocoordinates.html %}
 
-## Create a data object with custom vectors
+## Create a data object with a custom vector
 
-When you don't want to use a vectorizer to calculate a vector for your data object, and want to enter the vector yourself, you can this this as follows. 
+When creating a data object, you can configure Weaviate to generate a vector with a vectorizer module, or you can provide the vector yourself. We sometimes refer to this as a "custom" vector. 
 
-1. First, make sure that the `"vectorizer"` in the right class in the [data schema](../schema/schema-configuration.html#vectorizer) is either set to
-- `"none"` (`"vectorizer": "none"`), if you are running without any modules and have therefore already configured the default vectorizer to be `"none"` (`DEFAULT_VECTORIZER_MODULE="none"`), you can omit this step.
-- the same vectorizer with identical settings that you use to generate the vector that is entered.
-*Note: There is NO validation of this vector besides checking the vector length.* 
+You can provide a custom vector during object creation for either when:
+- you are not using a vectorizer for that class, or
+- you are using a vectorizer, but you wish to bypass it during the object creation stage.
 
-2. Then, attach the vector in a special `"vector"` field. An example of this looks like: 
+You can create a data object with a custom vector as follows:
+
+1. Set the `"vectorizer"` in the relevant class in the [data schema](../schema/schema-configuration.html#vectorizer). 
+
+    - If you are not using a vectorizer at all, configure the class accordingly. To do this, you can:
+        - set the default vectorizer module to `"none"` (`DEFAULT_VECTORIZER_MODULE="none"`), or
+        - set the `"vectorizer"` for the class to `"none"` (`"vectorizer": "none"`) (*note: the class `vectorizer` setting will override the `DEFAULT_VECTORIZER_MODULE` parameter*).
+    - If you wish to bypass the vectorizer for object creation:
+        - set the vectorizer to the same vectorizer with identical settings used to generate the custom vector
+
+    > *Note: There is NO validation of this vector besides checking the vector length.* 
+
+2. Then, attach the vector in a special `"vector"` field during object creation. For example, if adding a single object, you can:
+
+    > *Note: You can set custom vectors for batch imports as well as single object creation.*
 
 {% include code/1.x/semantic-kind.create.vector.html %}
 


### PR DESCRIPTION
### What's being changed:

Explicitly state that you can bring your own vector with a vectorizer present. [Motivated by this slack thread](https://weaviate.slack.com/archives/C017EG2SL3H/p1671639706214919).

### Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

[Added a test for the python client that explicitly checks this behavior (and updated the documentation there, too)](https://github.com/semi-technologies/weaviate-python-client/pull/196)
