### PR TITLE
Fix missing braces on .do Python example

### DIFF
--- a/_includes/code/1.x/howto.query.data.html
+++ b/_includes/code/1.x/howto.query.data.html
@@ -36,7 +36,7 @@ query_result = (
   client.query
   .get('Article', ['title', 'url', 'hasAuthors{... on Author {name}}'])
   .with_where(where_filter)
-  .do
+  .do()
 )
 print(query_result)
 {% endcapture %}


### PR DESCRIPTION
### Why:

Couldn't copy/paste example due to the missing braces.

### What's being changed:

Adding the braces to the .do call

### Type of change:

- [ ] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

Only locally