### PR TITLE
Added clarification about location curl text2vec

### DIFF
--- a/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.md
+++ b/developers/weaviate/current/retriever-vectorizer-modules/text2vec-transformers.md
@@ -181,7 +181,7 @@ ports:
 ```
 to your `text2vec-transformers`. 
 
-Then you can send REST requests to it directly, e.g. `curl localhost:9090/vectors -d '{"text": "foo bar"}'` and it will print the created vector directly. 
+Then you can send REST requests to it directly, e.g. `curl localhost:9090/vectors/ -d '{"text": "foo bar"}'` and it will print the created vector directly. 
 
 # How to configure
 


### PR DESCRIPTION
Changed `curl localhost:9090/vectors -d '{"text": "foo bar"}' to `curl localhost:9090/vectors/ -d '{"text": "foo bar"}'

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

This PR fixes: no particular issue, just a small typo in documentation

### What's being changed:

Changed `curl localhost:9090/vectors -d '{"text": "foo bar"}' to `curl localhost:9090/vectors/ -d '{"text": "foo bar"}'

### Type of change:

- [x ] Documentation updates (non-breaking change which updates documents)

### How Has This Been Tested?

This is the curl endpoint that works, as also attested in Slack
